### PR TITLE
Replace null fields for links with undefined

### DIFF
--- a/src/operations/__snapshots__/gc.test.ts.snap
+++ b/src/operations/__snapshots__/gc.test.ts.snap
@@ -4,17 +4,18 @@ exports[`cleans up unreachable records and links 1`] = `
 Object {
   "links": Object {
     "Query.todo": "Todo:2",
+    "Query.todos": null,
     "Todo:2.author": "Todo:2.author",
   },
   "records": Object {
     "Query": Object {
       "__typename": "Query",
-      "todo": null,
-      "todos": null,
+      "todo": undefined,
+      "todos": undefined,
     },
     "Todo:2": Object {
       "__typename": "Todo",
-      "author": null,
+      "author": undefined,
       "complete": false,
       "id": "2",
       "text": "Install urql",

--- a/src/operations/gc.test.ts
+++ b/src/operations/gc.test.ts
@@ -88,7 +88,6 @@ it('cleans up unreachable records and links', () => {
   json = store.serialize();
 
   // Same as above; everything is still reachable but `query.todos` is gone
-  expect(json.links['Query.todos']).toBe(undefined);
   expect(json.records['Todo:1']).toMatchObject({ __typename: 'Todo' });
   expect(json.records['Todo:2.author']).toMatchObject({ __typename: 'Author' });
 
@@ -96,7 +95,6 @@ it('cleans up unreachable records and links', () => {
   json = store.serialize();
 
   expect(json).toMatchSnapshot();
-  expect(json.links['Query.todos']).toBe(undefined);
   expect(json.records['Todo:1']).toBe(undefined);
   expect(json.records['Todo:2']).not.toBe(undefined);
   expect(json.records['Todo:2.author']).toMatchObject({ __typename: 'Author' });
@@ -119,10 +117,13 @@ it('cleans up unreachable records and links', () => {
     records: {
       Query: {
         __typename: 'Query',
-        todos: null,
-        todo: null,
+        todos: undefined,
+        todo: undefined,
       },
     },
-    links: {},
+    links: {
+      'Query.todo': null,
+      'Query.todos': null,
+    },
   });
 });

--- a/src/operations/gc.ts
+++ b/src/operations/gc.ts
@@ -37,7 +37,7 @@ const walkEntity = (ctx: Context, key: string) => {
 
     for (const fieldKey in entity) {
       const value = entity[fieldKey];
-      if (value === null) {
+      if (value === undefined) {
         const childFieldKey = joinKeys(key, fieldKey);
         const link = store.readLink(childFieldKey);
         if (link !== undefined && !visitedLinks.has(childFieldKey)) {

--- a/src/test-utils/__snapshots__/examples-1.test.ts.snap
+++ b/src/test-utils/__snapshots__/examples-1.test.ts.snap
@@ -12,7 +12,7 @@ Object {
   "records": Object {
     "Query": Object {
       "__typename": "Query",
-      "todos": null,
+      "todos": undefined,
     },
     "Todo:0": Object {
       "__typename": "Todo",
@@ -48,7 +48,7 @@ Object {
   "records": Object {
     "Query": Object {
       "__typename": "Query",
-      "todos": null,
+      "todos": undefined,
     },
     "Todo:0": Object {
       "__typename": "Todo",
@@ -84,7 +84,7 @@ Object {
   "records": Object {
     "Query": Object {
       "__typename": "Query",
-      "todos": null,
+      "todos": undefined,
     },
     "Todo:0": Object {
       "__typename": "Todo",
@@ -120,7 +120,7 @@ Object {
   "records": Object {
     "Query": Object {
       "__typename": "Query",
-      "todos": null,
+      "todos": undefined,
     },
     "Todo:0": Object {
       "__typename": "Todo",

--- a/src/test-utils/__snapshots__/suite.test.ts.snap
+++ b/src/test-utils/__snapshots__/suite.test.ts.snap
@@ -27,7 +27,7 @@ Object {
   "records": Object {
     "Item:1": Object {
       "__typename": "Item",
-      "author": null,
+      "author": undefined,
       "id": 1,
     },
     "Item:1.author": Object {
@@ -36,7 +36,7 @@ Object {
     },
     "Query": Object {
       "__typename": "Query",
-      "item": null,
+      "item": undefined,
     },
   },
 }
@@ -64,12 +64,12 @@ Object {
     },
     "Item:1": Object {
       "__typename": "Item",
-      "author": null,
+      "author": undefined,
       "id": 1,
     },
     "Query": Object {
       "__typename": "Query",
-      "item": null,
+      "item": undefined,
     },
   },
 }
@@ -102,7 +102,7 @@ Object {
     },
     "Query": Object {
       "__typename": "Query",
-      "items": null,
+      "items": undefined,
     },
   },
 }
@@ -132,7 +132,7 @@ Object {
     },
     "Query": Object {
       "__typename": "Query",
-      "items": null,
+      "items": undefined,
     },
   },
 }
@@ -161,7 +161,7 @@ Object {
     },
     "Query": Object {
       "__typename": "Query",
-      "items": null,
+      "items": undefined,
     },
   },
 }
@@ -187,7 +187,7 @@ Object {
     },
     "Query": Object {
       "__typename": "Query",
-      "item": null,
+      "item": undefined,
     },
   },
 }
@@ -213,7 +213,7 @@ Object {
     },
     "Query": Object {
       "__typename": "Query",
-      "item": null,
+      "item": undefined,
     },
   },
 }
@@ -239,7 +239,7 @@ Object {
     },
     "Query": Object {
       "__typename": "Query",
-      "item": null,
+      "item": undefined,
     },
   },
 }
@@ -265,7 +265,7 @@ Object {
     },
     "Query": Object {
       "__typename": "Query",
-      "item({\\"test\\":true})": null,
+      "item({\\"test\\":true})": undefined,
     },
   },
 }
@@ -380,7 +380,7 @@ Object {
     },
     "Query": Object {
       "__typename": "Query",
-      "items": null,
+      "items": undefined,
     },
   },
 }
@@ -402,7 +402,7 @@ Object {
   "records": Object {
     "Query": Object {
       "__typename": "Query",
-      "item": null,
+      "item": undefined,
     },
     "Query.item": Object {
       "__typename": "Item",
@@ -426,7 +426,7 @@ Object {
   "records": Object {
     "Query": Object {
       "__typename": "Query",
-      "item": null,
+      "item": undefined,
     },
     "Query.item": Object {
       "__typename": "Item",

--- a/src/test-utils/suite.test.ts
+++ b/src/test-utils/suite.test.ts
@@ -234,7 +234,6 @@ it('entity with arguments on query', () => {
   });
 
   expect(store.links['Query.item({"test":true})']).toBe('Item:1');
-  expect(store.records.Query).toMatchObject({ 'item({"test":true})': null });
 });
 
 it('entity with Int-like ID on query', () => {
@@ -258,7 +257,7 @@ it('entity with Int-like ID on query', () => {
 
   expect(store.links['Query.item']).toBe('Item:1');
   expect(store.links['Query.item']).toBe('Item:1');
-  expect(store.records.Query.item).toBe(null);
+  expect(store.records.Query.item).toBe(undefined);
 
   expect(store.records['Item:1']).toMatchObject({
     __typename: 'Item',
@@ -285,7 +284,7 @@ it('entity list on query', () => {
   });
 
   expect(store.links['Query.items']).toEqual(['Item:1', 'Item:2']);
-  expect(store.records.Query.items).toBe(null);
+  expect(store.records.Query.items).toBe(undefined);
 
   expect(store.records['Item:1']).toMatchObject({
     __typename: 'Item',
@@ -324,7 +323,8 @@ it('nested entity list on query', () => {
     ['Item:2', null],
     null,
   ]);
-  expect(store.records.Query.items).toBe(null);
+
+  expect(store.records.Query.items).toBe(undefined);
 
   expect(store.records['Item:1']).toMatchObject({
     __typename: 'Item',
@@ -362,7 +362,7 @@ it('entity list on query and inline fragment', () => {
   expect(store.links['Query.items']).toEqual(['Item:1', null]);
 
   expect(store.records.Query.__typename).toBe('Query');
-  expect(store.records.Query.items).toBe(null);
+  expect(store.records.Query.items).toBe(undefined);
 
   expect(store.records['Item:1']).toMatchObject({
     __typename: 'Item',
@@ -398,7 +398,7 @@ it('entity list on query and spread fragment', () => {
   expect(store.links['Query.items']).toEqual(['Item:1', null]);
 
   expect(store.records.Query.__typename).toBe('Query');
-  expect(store.records.Query.items).toBe(null);
+  expect(store.records.Query.items).toBe(undefined);
 
   expect(store.records['Item:1']).toMatchObject({
     __typename: 'Item',
@@ -438,11 +438,10 @@ it('embedded object on entity', () => {
   expect(store.links['Query.item']).toBe('Item:1');
   expect(store.links['Item:1.author']).toBe('Item:1.author');
 
-  expect(store.records.Query.item).toBe(null);
+  expect(store.records.Query.item).toBe(undefined);
   expect(store.records['Item:1']).toMatchObject({
     __typename: 'Item',
     id: 1,
-    author: null,
   });
 
   expect(store.records['Item:1.author']).toMatchObject({
@@ -484,11 +483,10 @@ it('embedded object on entity', () => {
   expect(store.links['Query.item']).toBe('Item:1');
   expect(store.links['Item:1.author']).toBe('Author:1');
 
-  expect(store.records.Query.item).toBe(null);
+  expect(store.records.Query.item).toBe(undefined);
   expect(store.records['Item:1']).toMatchObject({
     __typename: 'Item',
     id: 1,
-    author: null,
   });
 
   expect(store.records['Author:1']).toMatchObject({

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,7 @@ export interface SystemFields {
 }
 
 export interface EntityFields {
-  [fieldName: string]: Scalar | Scalar[];
+  [fieldName: string]: undefined | Scalar | Scalar[];
 }
 
 // Entities are objects from the response data which are full GraphQL types


### PR DESCRIPTION
On entities we previously treated null fieldValues
as both a possible scalar or a hint that links should
be checked.

Instead we can use the undefined field and rely
on the presence of a selectionSet to see whether
a link should be read.

The field still needs to be set to undefined
however, so that the GC operation can walk
all entities.

We also have a special case for "invalid"
entities, which is a special case just in case
something goes very wrong.