### PR TITLE
(feat) - fragment matcher

### DIFF
--- a/src/ast/traversal.ts
+++ b/src/ast/traversal.ts
@@ -100,6 +100,10 @@ export const forEachFieldNode = (
         const fragmentSelect = getSelectionSet(def);
         // TODO: Check for getTypeCondition(def) to match
         // Recursively process the fragments' selection sets
+        // TODO: add fragmentMatcher here, that would imply this
+        // being expanded with store as an argument.
+        // This could entail potential issues... Do we just return
+        // when we don't match or do we error out?
         forEachFieldNode(fragmentSelect, fragments, vars, cb);
       }
     } else if (getName(node) !== '__typename') {

--- a/src/ast/traversal.ts
+++ b/src/ast/traversal.ts
@@ -12,10 +12,7 @@ import {
 import { getName, getSelectionSet } from './node';
 import { evaluateValueNode } from './variables';
 import { Fragments, Variables, SelectionSet } from '../types';
-import {
-  matchFragment,
-  matchFragmentHeuristically,
-} from '../fragments/matcher';
+import { matchFragment, matchFragmentHeuristically } from '../fragments';
 import { Store } from '../store';
 
 const isFragmentNode = (

--- a/src/fragments/index.ts
+++ b/src/fragments/index.ts
@@ -1,0 +1,1 @@
+export * from './matcher';

--- a/src/fragments/matcher.test.ts
+++ b/src/fragments/matcher.test.ts
@@ -1,0 +1,80 @@
+import gql from 'graphql-tag';
+import { matchFragment } from './matcher';
+import { Store } from '../store';
+import { write } from '../operations';
+
+const todosData = {
+  __typename: 'Query',
+  todos: [
+    {
+      id: '0',
+      text: 'Go to the shops',
+      complete: false,
+      __typename: 'Todo',
+      author: { id: '0', name: 'Jovi', __typename: 'Author' },
+    },
+    {
+      id: '1',
+      text: 'Pick up the kids',
+      complete: true,
+      __typename: 'Todo',
+      author: { id: '1', name: 'Phil', __typename: 'Author' },
+    },
+    {
+      id: '2',
+      text: 'Install urql',
+      complete: false,
+      __typename: 'Todo',
+      author: { id: '0', name: 'Jovi', __typename: 'Author' },
+    },
+  ],
+};
+
+describe('fragmentMatcher', () => {
+  let store, query;
+  beforeEach(() => {
+    store = new Store();
+    query = gql`
+      query {
+        todos {
+          id
+          __typename
+          ...TodoData
+        }
+      }
+      fragment TodoData on Todo {
+        text
+        complete
+      }
+    `;
+    write(store, { query }, todosData);
+  });
+
+  it('can match a fragment', () => {
+    const fragmentQuery = gql`
+      fragment TodoData on Todo {
+        text
+        complete
+      }
+    `;
+    expect(matchFragment(store, 'Todo:1', fragmentQuery.definitions[0])).toBe(
+      true
+    );
+  });
+
+  it('returns true for Query', () => {
+    const fragmentQuery = gql`
+      fragment Todos on Query {
+        todos {
+          id
+          text
+          complete
+          __typename
+        }
+      }
+    `;
+    expect(matchFragment(store, 'Query', fragmentQuery.definitions[0])).toBe(
+      true
+    );
+  });
+});

--- a/src/fragments/matcher.test.ts
+++ b/src/fragments/matcher.test.ts
@@ -1,5 +1,5 @@
 import gql from 'graphql-tag';
-import { matchFragment, matchFragmentHeuristically } from './index';
+import { matchFragment, matchFragmentHeuristically } from '.';
 import { Store } from '../store';
 import { write } from '../operations';
 

--- a/src/fragments/matcher.test.ts
+++ b/src/fragments/matcher.test.ts
@@ -1,5 +1,5 @@
 import gql from 'graphql-tag';
-import { matchFragment } from './matcher';
+import { matchFragment, matchFragmentHeuristically } from './index';
 import { Store } from '../store';
 import { write } from '../operations';
 
@@ -75,6 +75,24 @@ describe('fragmentMatcher', () => {
     `;
     expect(matchFragment(store, 'Query', fragmentQuery.definitions[0])).toBe(
       true
+    );
+  });
+
+  it('warns for unavailable property on a fragment', () => {
+    const fragmentQuery = gql`
+      fragment TodoDataNonExistantProperty on Todo {
+        text
+        complete
+        doesNotExist
+      }
+    `;
+    jest.spyOn(console, 'warn');
+    expect(
+      matchFragmentHeuristically(store, 'Todo:1', fragmentQuery.definitions[0])
+    ).toBe(true);
+    expect(console.warn).toBeCalledTimes(1);
+    expect(console.warn).toHaveBeenLastCalledWith(
+      'Missing field "doesNotExist"'
     );
   });
 });

--- a/src/fragments/matcher.ts
+++ b/src/fragments/matcher.ts
@@ -9,7 +9,6 @@ export const matchFragment = (
 ): boolean | 'heuristic' => {
   const typeCondition = getTypeCondition(fragment);
   const typename = store.getRecord(`${key}.__typename`);
-  if (typename === 'Query') return true;
   // The name and condition are equals so we know they are matched.
   if (typeCondition === typename) return true;
   // We can't know for sure without the schema.

--- a/src/fragments/matcher.ts
+++ b/src/fragments/matcher.ts
@@ -1,11 +1,11 @@
-import { FragmentDefinitionNode, FieldNode } from 'graphql';
+import { FragmentDefinitionNode, FieldNode, InlineFragmentNode } from 'graphql';
 import { getTypeCondition, getName, getSelectionSet } from '../ast';
 import { Store } from '../store';
 
 export const matchFragment = (
   store: Store,
   key: string,
-  fragment: FragmentDefinitionNode
+  fragment: FragmentDefinitionNode | InlineFragmentNode
 ): boolean | 'heuristic' => {
   const typeCondition = getTypeCondition(fragment);
   const typename = store.getRecord(`${key}.__typename`);
@@ -20,12 +20,13 @@ export const matchFragment = (
 export const matchFragmentHeuristically = (
   store: Store,
   key: string,
-  fragment: FragmentDefinitionNode
+  fragment: FragmentDefinitionNode | InlineFragmentNode
 ) => {
   const missing: string[] = [];
   getSelectionSet(fragment).forEach(selection => {
     const fieldName = getName(selection as FieldNode);
-    if (!store.getRecord(`${key}.${fieldName}`)) {
+
+    if (store.getRecord(`${key}.${fieldName}`) === undefined) {
       missing.push(fieldName);
     }
   });

--- a/src/fragments/matcher.ts
+++ b/src/fragments/matcher.ts
@@ -1,0 +1,19 @@
+import { FragmentDefinitionNode } from 'graphql';
+import { getTypeCondition } from '../ast';
+import { Store } from '../store';
+
+export const matchFragment = (
+  store: Store,
+  key: string,
+  fragment: FragmentDefinitionNode
+): boolean | 'heuristic' => {
+  const typeCondition = getTypeCondition(fragment);
+  const typename = store.getRecord(`${key}.__typename`);
+  if (typename === 'Query') return true;
+  // The name and condition are equals so we know they are matched.
+  if (typeCondition === typename) return true;
+  // We can't know for sure without the schema.
+  // When we return 'heuristic' + have missing fragmentFields
+  // We know we're making a mistake.
+  return 'heuristic';
+};

--- a/src/fragments/matcher.ts
+++ b/src/fragments/matcher.ts
@@ -1,5 +1,5 @@
-import { FragmentDefinitionNode } from 'graphql';
-import { getTypeCondition } from '../ast';
+import { FragmentDefinitionNode, FieldNode } from 'graphql';
+import { getTypeCondition, getName, getSelectionSet } from '../ast';
 import { Store } from '../store';
 
 export const matchFragment = (
@@ -15,4 +15,23 @@ export const matchFragment = (
   // When we return 'heuristic' + have missing fragmentFields
   // We know we're making a mistake.
   return 'heuristic';
+};
+
+export const matchFragmentHeuristically = (
+  store: Store,
+  key: string,
+  fragment: FragmentDefinitionNode
+) => {
+  const missing: string[] = [];
+  getSelectionSet(fragment).forEach(selection => {
+    const fieldName = getName(selection as FieldNode);
+    if (!store.getRecord(`${key}.${fieldName}`)) {
+      missing.push(fieldName);
+    }
+  });
+
+  if (missing.length > 0) {
+    missing.forEach(name => console.warn('Missing field ', name));
+  }
+  return missing.length > 0;
 };

--- a/src/fragments/matcher.ts
+++ b/src/fragments/matcher.ts
@@ -1,4 +1,9 @@
-import { FragmentDefinitionNode, FieldNode, InlineFragmentNode } from 'graphql';
+import {
+  FragmentDefinitionNode,
+  FieldNode,
+  InlineFragmentNode,
+  Kind,
+} from 'graphql';
 import { getTypeCondition, getName, getSelectionSet } from '../ast';
 import { Store } from '../store';
 
@@ -23,16 +28,19 @@ export const matchFragmentHeuristically = (
   fragment: FragmentDefinitionNode | InlineFragmentNode
 ) => {
   const missing: string[] = [];
-  getSelectionSet(fragment).forEach(selection => {
-    const fieldName = getName(selection as FieldNode);
+  getSelectionSet(fragment).forEach(node => {
+    if (node.kind === Kind.FIELD) {
+      const fieldName = getName(node as FieldNode);
 
-    if (store.getRecord(`${key}.${fieldName}`) === undefined) {
-      missing.push(fieldName);
+      if (store.getRecord(`${key}.${fieldName}`) === undefined) {
+        missing.push(fieldName);
+      }
     }
   });
 
   if (missing.length > 0 && process.env.NODE_ENV !== 'production') {
     missing.forEach(name => console.warn(`Missing field "${name}"`));
   }
+
   return missing.length > 0;
 };

--- a/src/fragments/matcher.ts
+++ b/src/fragments/matcher.ts
@@ -31,8 +31,8 @@ export const matchFragmentHeuristically = (
     }
   });
 
-  if (missing.length > 0) {
-    missing.forEach(name => console.warn('Missing field ', name));
+  if (missing.length > 0 && process.env.NODE_ENV !== 'production') {
+    missing.forEach(name => console.warn(`Missing field "${name}"`));
   }
   return missing.length > 0;
 };

--- a/src/operations/query.ts
+++ b/src/operations/query.ts
@@ -84,7 +84,7 @@ const readSelection = (
 
   data.__typename = typename;
 
-  forEachFieldNode(select, fragments, variables, node => {
+  forEachFieldNode(entityKey, ctx.store, select, fragments, variables, node => {
     // Derive the needed data from our node.
     const fieldName = getName(node);
     const fieldArgs = getFieldArguments(node, variables);

--- a/src/operations/write.ts
+++ b/src/operations/write.ts
@@ -117,7 +117,7 @@ const writeSelection = (
   const { store, fragments, variables } = ctx;
   store.writeField(data.__typename, entityKey, '__typename');
 
-  forEachFieldNode(select, fragments, variables, node => {
+  forEachFieldNode(entityKey, ctx.store, select, fragments, variables, node => {
     const fieldName = getName(node);
     const fieldArgs = getFieldArguments(node, variables);
     const fieldKey = joinKeys(entityKey, keyOfField(fieldName, fieldArgs));
@@ -171,7 +171,7 @@ const writeField = (
 // This is like writeSelection but assumes no parent entity exists
 const writeRoot = (ctx: Context, select: SelectionSet, data: Data) => {
   const { fragments, variables } = ctx;
-  forEachFieldNode(select, fragments, variables, node => {
+  forEachFieldNode('Query', ctx.store, select, fragments, variables, node => {
     const fieldName = getName(node);
     const fieldAlias = getFieldAlias(node);
     const fieldArgs = getFieldArguments(node, variables);


### PR DESCRIPTION
This implements a really basic `match` function. This checks if the TypeCondition provided by the `on` keyword in a graphql statement and the __typename of the requested entity are matching. If not we should not return any data or not write at all.

I'm not entirely sure if our `forEachFieldNode` allows this for now, since when we can't be sure about the match (union/interface) we should be able to tell the graphCache consumer what exactly is missing and why the consumer needs schema awareness.