### PR TITLE
(tests) - optimistic updates

### DIFF
--- a/src/operations/write.ts
+++ b/src/operations/write.ts
@@ -99,17 +99,10 @@ export const writeOptimistic = (
         const resolver = ctx.store.optimisticMutations[fieldName];
         if (resolver !== undefined) {
           const fieldArgs = getFieldArguments(node, ctx.variables);
-          const fieldSelect = getSelectionSet(operation);
+          const fieldSelect = getSelectionSet(node);
           const resolverValue = resolver(fieldArgs || {}, ctx.store, ctx);
           if (!isScalar(resolverValue)) {
-            writeRootField(
-              ctx,
-              resolverValue,
-              // We want to avoid passing [mutationName]: fieldSelection
-              // since this will make us write [mutationName]: undefined
-              // to the store. This because data[mutationName] does not exist.
-              (fieldSelect[0] as any).selectionSet.selections
-            );
+            writeRootField(ctx, resolverValue, fieldSelect);
           }
         }
       }

--- a/src/operations/write.ts
+++ b/src/operations/write.ts
@@ -105,6 +105,9 @@ export const writeOptimistic = (
             writeRootField(
               ctx,
               resolverValue,
+              // We want to avoid passing [mutationName]: fieldSelection
+              // since this will make us write [mutationName]: undefined
+              // to the store. This because data[mutationName] does not exist.
               (fieldSelect[0] as any).selectionSet.selections
             );
           }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -50,8 +50,9 @@ export const clearStoreState = () => {
 export const getCurrentDependencies = () => refValue(currentDependencies);
 
 // Add a dependency to the internal store state
-export const addDependency = (dependency: string) =>
+export const addDependency = (dependency: string) => {
   refValue(currentDependencies).add(dependency);
+};
 
 const mapSet = <T>(map: Pessimism.Map<T>, key: string, value: T) => {
   const optimisticKey = refValue(currentOptimisticKey);
@@ -147,11 +148,13 @@ export class Store {
 
   resolve(entity: SystemFields, field: string, args?: Variables): DataField {
     if (typeof entity === 'string') {
+      addDependency(entity);
       return this.resolveValueOrLink(joinKeys(entity, keyOfField(field, args)));
     } else {
       // This gives us __typename:key
       const entityKey = keyOfEntity(entity);
       if (entityKey === null) return null;
+      addDependency(entityKey);
       return this.resolveValueOrLink(
         joinKeys(entityKey, keyOfField(field, args))
       );

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -1,5 +1,10 @@
 import gql from 'graphql-tag';
-import { Store, initStoreState, clearStoreState } from '.';
+import {
+  Store,
+  initStoreState,
+  clearStoreState,
+  getCurrentDependencies,
+} from '.';
 import { write, query } from '../operations';
 import { Data } from '../types';
 import { writeOptimistic } from '../operations/write';
@@ -57,8 +62,8 @@ describe('store', () => {
         },
       ],
     };
-
     write(store, { query: Todos }, todosData);
+    initStoreState(null);
   });
 
   it('Should resolve a property', () => {
@@ -72,15 +77,17 @@ describe('store', () => {
     const result = store.resolve({ id: 0, __typename: 'Todo' }, 'text');
     expect(result).toEqual('Go to the shops');
     // TODO: we have no way of asserting this to really be the case.
-    // const deps = getCurrentDependencies();
-    // expect(deps).toEqual(new Set(['Todo:0', 'Author:0']))
+    const deps = getCurrentDependencies();
+    expect(deps).toEqual(new Set(['Todo:0', 'Author:0']));
+    clearStoreState();
   });
 
   it('should resolve witha key as first argument', () => {
     const authorResult = store.resolve('Author:0', 'name');
     expect(authorResult).toBe('Jovi');
-    // const deps = getCurrentDependencies();
-    // expect(deps).toEqual(new Set(['Author:0']))
+    const deps = getCurrentDependencies();
+    expect(deps).toEqual(new Set(['Author:0']));
+    clearStoreState();
   });
 
   it('Should resolve a link property', () => {
@@ -92,8 +99,9 @@ describe('store', () => {
     };
     const result = store.resolve(parent, 'author');
     expect(result).toEqual('Author:0');
-    // const deps = getCurrentDependencies();
-    // expect(deps).toEqual(new Set(['Author:0']))
+    const deps = getCurrentDependencies();
+    expect(deps).toEqual(new Set(['Todo:0']));
+    clearStoreState();
   });
 
   it('should be able to update a fragment', () => {
@@ -113,11 +121,10 @@ describe('store', () => {
       }
     );
 
-    // const deps = getCurrentDependencies();
-    // expect(deps).toEqual(new Set(['Todo:0']))
+    const deps = getCurrentDependencies();
+    expect(deps).toEqual(new Set(['Todo:0']));
 
     const { data } = query(store, { query: Todos });
-    clearStoreState();
 
     expect(data).toEqual({
       __typename: 'Query',
@@ -131,6 +138,7 @@ describe('store', () => {
         todosData.todos[2],
       ],
     });
+    clearStoreState();
   });
 
   it('should be able to update a query', () => {
@@ -168,6 +176,7 @@ describe('store', () => {
         },
       ],
     });
+    clearStoreState();
   });
 
   it('should be able to optimistically mutate', () => {

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -202,7 +202,7 @@ describe('store', () => {
       1
     );
     expect(dependencies).toEqual(new Set(['Todo:1']));
-    const { data } = query(store, { query: Todos });
+    let { data } = query(store, { query: Todos });
     expect(data).toEqual({
       __typename: 'Query',
       todos: [
@@ -220,6 +220,13 @@ describe('store', () => {
         },
         todosData.todos[2],
       ],
+    });
+
+    store.clearOptimistic(1);
+    ({ data } = query(store, { query: Todos }));
+    expect(data).toEqual({
+      __typename: 'Query',
+      todos: todosData.todos,
     });
   });
 });


### PR DESCRIPTION
I have found a bug as mentioned in slack where we enter on the addTodo field, this results in a noop in writing. We should skip the mutationName field when writing.

Also noticed we can't really test the dependencies as compared to https://github.com/FormidableLabs/urql-exchange-graphcache/pull/17/files#diff-4e717be21ea17e42d450798659a9e5eeR72

I think it's worth considering for testability on our side.