### PR TITLE
(fix) - default options and pass keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "peerDependencies": {
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0",
-    "urql": ">= 1.1.3"
+    "urql": ">= 1.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -76,7 +76,7 @@ export interface CacheExchangeOpts {
   keys?: KeyingConfig;
 }
 
-export const cacheExchange = (opts: CacheExchangeOpts): Exchange => ({
+export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
   forward,
   client,
 }) => {

--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -80,7 +80,13 @@ export const cacheExchange = (opts: CacheExchangeOpts): Exchange => ({
   forward,
   client,
 }) => {
-  const store = new Store(opts.resolvers, opts.updates, opts.optimistic);
+  if (!opts) opts = {};
+  const store = new Store(
+    opts.resolvers,
+    opts.updates,
+    opts.optimistic,
+    opts.keys
+  );
   const optimisticKeys = new Set();
   const ops: OperationMap = new Map();
   const deps = Object.create(null) as DependentOperations;


### PR DESCRIPTION
- defaults options to an empty object, prevents crash
- passes keys to the store so they're used
- bumps peerDep to 1.3.0 so we have access to formatDocument

Point 1 and 3 crash the exchange.