### PR TITLE
Fix nested, keyless writes being skipped over (writeRootField)

### DIFF
--- a/src/operations/write.ts
+++ b/src/operations/write.ts
@@ -258,6 +258,9 @@ const writeRootField = (
   const entityKey = ctx.store.keyOfEntity(data);
   if (entityKey !== null) {
     writeSelection(ctx, entityKey, select, data);
+  } else {
+    const typename = data.__typename;
+    writeRoot(ctx, typename, select, data);
   }
 };
 


### PR DESCRIPTION
When we write mutations or subscriptions, we don't write the root of them to the store. This is because they don't relate to `Query` and hence don't have keys relating to `Query`.

Instead we call `writeRoot` which writes the root entity without any key and falls back to skipping over keyless entities. Instead of skipping keyless entities however, we now recursively call `writeRoot`.