### PR TITLE
(fix) - invariant stripping

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "@typescript-eslint/eslint-plugin": "^1.13.0",
     "@typescript-eslint/parser": "^1.13.0",
     "babel-plugin-closure-elimination": "^1.3.0",
-    "babel-plugin-strip-invariant": "^1.0.0",
     "babel-plugin-transform-async-to-promises": "^0.8.14",
     "babel-plugin-transform-dev-warning": "^0.1.1",
     "codecov": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "@typescript-eslint/parser": "^1.13.0",
     "babel-plugin-closure-elimination": "^1.3.0",
     "babel-plugin-transform-async-to-promises": "^0.8.14",
-    "babel-plugin-transform-dev-warning": "^0.1.1",
     "codecov": "^3.5.0",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,7 @@ import buble from 'rollup-plugin-buble';
 import babel from 'rollup-plugin-babel';
 import { terser } from 'rollup-plugin-terser';
 import replace from 'rollup-plugin-replace';
+import transfromInvariant from './scripts/transform-invariant';
 
 const pkgInfo = require('./package.json');
 const { main, peerDependencies, dependencies } = pkgInfo;
@@ -79,13 +80,13 @@ const terserMinified = terser({
 const makePlugins = (isProduction = false) => [
   nodeResolve({
     mainFields: ['module', 'jsnext', 'main'],
-    browser: true
+    browser: true,
   }),
   commonjs({
     ignoreGlobal: true,
     include: /\/node_modules\//,
     namedExports: {
-      'react': Object.keys(require('react'))
+      react: Object.keys(require('react')),
     },
   }),
   typescript({
@@ -94,16 +95,12 @@ const makePlugins = (isProduction = false) => [
     useTsconfigDeclarationDir: true,
     tsconfigDefaults: {
       compilerOptions: {
-        sourceMap: true
+        sourceMap: true,
       },
     },
     tsconfigOverride: {
-     exclude: [
-       'src/**/*.test.ts',
-       'src/**/*.test.tsx',
-       'src/**/test-utils/*'
-     ],
-     compilerOptions: {
+      exclude: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'src/**/test-utils/*'],
+      compilerOptions: {
         declaration: !isProduction,
         declarationDir: './dist/types/',
         target: 'es6',
@@ -114,10 +111,10 @@ const makePlugins = (isProduction = false) => [
     transforms: {
       unicodeRegExp: false,
       dangerousForOf: true,
-      dangerousTaggedTemplateString: true
+      dangerousTaggedTemplateString: true,
     },
     objectAssign: 'Object.assign',
-    exclude: 'node_modules/**'
+    exclude: 'node_modules/**',
   }),
   babel({
     babelrc: false,
@@ -126,24 +123,31 @@ const makePlugins = (isProduction = false) => [
     presets: [],
     plugins: [
       ['babel-plugin-transform-dev-warning', {}],
-      ['babel-plugin-strip-invariant', {}],
+      transfromInvariant,
       ['babel-plugin-closure-elimination', {}],
       ['@babel/plugin-transform-object-assign', {}],
-      ['@babel/plugin-transform-react-jsx', {
-        pragma: 'React.createElement',
-        pragmaFrag: 'React.Fragment',
-        useBuiltIns: true
-      }],
-      ['babel-plugin-transform-async-to-promises', {
-        inlineHelpers: true,
-        externalHelpers: true
-      }]
-    ]
+      [
+        '@babel/plugin-transform-react-jsx',
+        {
+          pragma: 'React.createElement',
+          pragmaFrag: 'React.Fragment',
+          useBuiltIns: true,
+        },
+      ],
+      [
+        'babel-plugin-transform-async-to-promises',
+        {
+          inlineHelpers: true,
+          externalHelpers: true,
+        },
+      ],
+    ],
   }),
-  isProduction && replace({
-    'process.env.NODE_ENV': JSON.stringify('production')
-  }),
-  isProduction ? terserMinified : terserPretty
+  isProduction &&
+    replace({
+      'process.env.NODE_ENV': JSON.stringify('production'),
+    }),
+  isProduction ? terserMinified : terserPretty,
 ];
 
 const config = {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,7 @@ import buble from 'rollup-plugin-buble';
 import babel from 'rollup-plugin-babel';
 import { terser } from 'rollup-plugin-terser';
 import replace from 'rollup-plugin-replace';
-import transfromInvariant from './scripts/transform-invariant';
+import transfromInvariantWarning from './scripts/transform-invariant-warning';
 
 const pkgInfo = require('./package.json');
 const { main, peerDependencies, dependencies } = pkgInfo;
@@ -122,8 +122,7 @@ const makePlugins = (isProduction = false) => [
     exclude: 'node_modules/**',
     presets: [],
     plugins: [
-      ['babel-plugin-transform-dev-warning', {}],
-      transfromInvariant,
+      transfromInvariantWarning,
       ['babel-plugin-closure-elimination', {}],
       ['@babel/plugin-transform-object-assign', {}],
       [

--- a/scripts/transform-invariant-warning.js
+++ b/scripts/transform-invariant-warning.js
@@ -1,5 +1,4 @@
-const visited = 'visitedByInvariantTransformer';
-const pragma = 'invariant';
+const visited = 'visitedByInvariantWarningTransformer';
 
 export default function Plugin({ template }) {
   const wrapWithDevCheck = template(
@@ -18,7 +17,7 @@ export default function Plugin({ template }) {
           CallExpression(path) {
             if (path.node[visited]) return
             path.node[visited] = true;
-            if (path.node.callee.name === pragma) {
+            if (path.node.callee.name === 'invariant' || path.node.callee.name === 'warning') {
               path.replaceWith(wrapWithDevCheck({ NODE: path.node }));
             }
           }

--- a/scripts/transform-invariant.js
+++ b/scripts/transform-invariant.js
@@ -1,0 +1,29 @@
+const visited = 'visitedByInvariantTransformer';
+const pragma = 'invariant';
+
+export default function Plugin({ template }) {
+  const wrapWithDevCheck = template(
+      `
+    if (process.env.NODE_ENV !== "production") {
+      NODE;
+    }
+  `,
+    { placeholderPattern: /^NODE$/ }
+  );
+
+  return {
+    visitor: {
+      Program(p) {
+        p.traverse({
+          CallExpression(path) {
+            if (path.node[visited]) return
+            path.node[visited] = true;
+            if (path.node.callee.name === pragma) {
+              path.replaceWith(wrapWithDevCheck({ NODE: path.node }));
+            }
+          }
+        })
+      },
+    },
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -925,11 +925,6 @@ babel-plugin-transform-async-to-promises@^0.8.14:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.14.tgz#8c783aecb1139f39c608f8bb0f5bb69c343c878e"
   integrity sha512-BHw2WriDbnLwaaIydAjVeXXKBal0pWlFWxfo0UKL2CTaSorvRocrsTflni/mzIOP8c+EJ8xHqtbre8GbIm4ehQ==
 
-babel-plugin-transform-dev-warning@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-dev-warning/-/babel-plugin-transform-dev-warning-0.1.1.tgz#9e3cca7c22b27a667486fda11bbce29c0c59e76e"
-  integrity sha512-3n6ptKAU1KqhfzmrQuI4Blyvt0T6vHCeaOpULKjAbU+5+JSePSeVorB+24SHe58/zxXsP4sm1q3crsDFD+UHYQ==
-
 babel-preset-jest@^24.6.0:
   version "24.6.0"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz#66f06136eefce87797539c0d63f1769cc3915984"

--- a/yarn.lock
+++ b/yarn.lock
@@ -920,11 +920,6 @@ babel-plugin-jest-hoist@^24.6.0:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
-babel-plugin-strip-invariant@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-strip-invariant/-/babel-plugin-strip-invariant-1.0.0.tgz#09d1046a0bf818f558535a4d7a87cbc4a6136d11"
-  integrity sha512-ZQcVDBlxcpKiayFfGq+YQs4JdR6E8k78JCFXaMpu33DL5pddrpAsYxv1Qm5Is1daT5OUdoNr7yuuTaRcSFn7GQ==
-
 babel-plugin-transform-async-to-promises@^0.8.14:
   version "0.8.14"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.14.tgz#8c783aecb1139f39c608f8bb0f5bb69c343c878e"


### PR DESCRIPTION
Replace argument stripping from invariant with removing it in production, something else that could be done is us replacing is with an error code.

The last plugin did the following in DEV and in PROD: remove the second argument which results in error throwing

Before:
```
browser(!!operation); --> throws when the user spins up dev-mode since it needs two arguments
```

After:

```
  "production" !== process.env.NODE_ENV && browser(!!operation, "Invalid GraphQL document: All GraphQL documents must contain an OperationDefinitionnode for a query, subscription, or mutation."); --> Does not throw and provides errors in dev-mode

```