### PR TITLE
Add clarifying language to the docs.

### DIFF
--- a/docs/keys.md
+++ b/docs/keys.md
@@ -3,11 +3,12 @@
 When resolving entities the graph cache will try to look at the entity
 and use `id` or `_id` to identify them.
 
-The keys property allows us to intervene in this behavior, we can point
-to another location or pre-/postfix it.
+The `keys` property allows us to intervene in this behavior by pointing
+to another location on the entity or by pre-/post-fixing it.
 
-Let's look at an example, we have a set of todos (typename is Todo),
-but instead of identifying on `id` or `_id` we are using the `name`.
+Let's look at an example. Say we have a set of todos each with `__typename`
+of `Todo`, but instead of identifying on `id` or `_id` we want to identify
+each record by its `name`.
 
 ```js
 const myGraphCache = cacheExchange({
@@ -17,16 +18,16 @@ const myGraphCache = cacheExchange({
 });
 ```
 
-Now when we query or write a Todo it will use `name` and all others
-will be resolved the traditional way.
+Now when we query or write a Todo it will use `name` to identify the record
+in the cache. All other records will be resolved the traditional way.
 
-In here you could for example say that a Todo meant only for admin
-access is prefixed with `admin`.
+In the same way, you could say that a Todo meant only for admin access is
+prefixed with `admin`.
 
 ```js
 const myGraphCache = cacheExchange({
   keys: {
-    Todo: data => (data.isAdminOnly ? `${admin}-${data.name}` : data.name),
+    Todo: data => (data.isAdminOnly ? `admin-${data.name}` : data.name),
   },
 });
 ```

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -6,7 +6,7 @@ and use `id` or `_id` to identify them.
 The `keys` property allows us to intervene in this behavior by pointing
 to another location on the entity or by pre-/post-fixing it.
 
-Let's look at an example. Say we have a set of todos each with `__typename`
+Let's look at an example. Say we have a set of todos each with a `__typename`
 of `Todo`, but instead of identifying on `id` or `_id` we want to identify
 each record by its `name`.
 

--- a/docs/optimistic.md
+++ b/docs/optimistic.md
@@ -3,17 +3,18 @@
 Let's say we want to work offline or we don't want to wait for
 responses from the server.
 
-Here we have optimistic responses as the solution. This is a mapping
-of the name of the mutation to a function. This function gets three
+Optimistic responses can be a great solution to this problem. Optimisitc
+responses are simply a mapping of the name of a mutation to a function.
+This function gets three
 arguments:
 
-- variables: The variables used to execute the mutation
-- cache: The cache we've already seen in [resolvers](./resolvers.md) and
+- `variables` – The variables used to execute the mutation.
+- `cache` – The cache we've already seen in [resolvers](./resolvers.md) and
   [updates](./updates.md). This can be used to get a certain entity/property
   from the cache.
-- info: Contains the used fragments and field arguments.
+- `info` – Contains the used fragments and field arguments.
 
-Let's approach this from an example.
+Let's see an example.
 
 ```js
 const myGraphCache = cacheExchange({
@@ -26,7 +27,7 @@ const myGraphCache = cacheExchange({
 });
 ```
 
-Now that we return variables our `Todo:1` will be updated to have
+Now that we return `variables` our `Todo:1` will be updated to have
 the new `text` property. In our cache this will form a layer above
 the property. When a response from the server comes in this layer
 will be removed and the response from the server will be used to

--- a/docs/resolvers.md
+++ b/docs/resolvers.md
@@ -1,7 +1,7 @@
 # Resolvers
 
-This is a way to alter the response you'll receive from the cache,
-so let's look at an example to get a better understanding.
+`resolvers` are a way to alter the response you'll receive from the cache.
+Let's look at an example to get a better understanding.
 
 ```js
 const cache = cacheExchange({
@@ -12,27 +12,30 @@ const cache = cacheExchange({
 ```
 
 Now when we query our `todos` every time we encounter an object with `Todo`
-as the `__typename` it will change the `text` to `secret`. So here we
-effectively change how we handle a certain property on an entity.
+as the `__typename` it will change the `text` to `'Secret'`. In this way we
+can effectively change how we handle a certain property on an entity.
 
-This looks pretty useless right now but let's look at what arguments
-are passed to this method so we can get a better understanding.
+This may seem pretty useless right now, but let's look at the arguments
+passed to `resolvers` to get a better sense of how powerful they are.
 
-A resolver gets four arguments:
+A `resolver` gets four arguments:
 
-- parent: in this case the result of the `Todo` up until us getting `text`
-- arguments: the arguments used in this field.
-- cache: this is the normalised cache, this cache provides us with a `resolve` method
-  more about this underneath.
-- info: contains the fragments used in the query and the field arguments in the query.
+- `parent` – The original entity in the cache. In the example above, this
+  would be the full `Todo` object.
+- `arguments` – The arguments used in this field.
+- `cache` – This is the normalized cache. The cache provides us with a `resolve` method;
+  see more about this [below](#cache.resolve).
+- `info` – This contains the fragments used in the query and the field arguments in the query.
 
-The `cache.resolve` method is used to get links and property values from the cache,
-our cache methods has three arguments:
+## `cache.resolve`
 
-- entity: this can either be an object containing a `__typename` and an `id` or `_id`.
-  This argument however can also be a string, this will be a key leading to a cached entity.
-- field: the field you want data for, this can be a relation or a single property.
-- arguments: the arguments to include on the field.
+The `cache.resolve` method is used to get links and property values from the cache.
+Our cache methods have three arguments:
+
+- `entity` – This can either be an object containing a `__typename` and an `id` or
+  `_id` field _or_ a string key leading to a cached entity.
+- `field` – The field you want data for. This can be a relation or a single property.
+- `arguments` – The arguments to include on the field.
 
 To get a better grasp let's look at a few examples.
 Consider the following data structure:
@@ -54,7 +57,7 @@ todos: [
 ];
 ```
 
-When we would use `resolve` to get the author it would look like this:
+Using `cache.resolve` to get the author would look like this:
 
 ```js
 const parent = {
@@ -68,7 +71,7 @@ const result = cache.resolve(parent, 'author');
 console.log(result); // 'Author:2'
 ```
 
-Now we have a stringed key that indicates our author, now we
+Now we have a stringed key that identifies our author. We
 can use this to derive the name of our author.
 
 ```js
@@ -76,7 +79,7 @@ const name = cache.resolve('Author:2', 'name');
 console.log(name); // 'Bar'
 ```
 
-This can solve practical use cases like for example date formatting,
-you can query the date and then convert it in your resolver.
+This can help solve practical use cases like date formatting,
+where you would query the date and then convert it in your resolver.
 
 [Back](../README.md)

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -1,18 +1,18 @@
 # Updates
 
 When the cache receives a response it will try and do its best to
-incorporate that answer into the current cache, but for adding and
+incorporate that response into the current cache. However, for adding and
 deleting entities it can't really make assumptions.
 
-That's where updates come into play. Analogue to our `resolvers` this gets
-arguments but instead of the parent argument (first one) we get the
+That's where updates come into play. Analogous to our `resolvers`,
+`updates` get arguments, but instead of the `parent` argument we get the
 result given from the server due to a subscription trigger or a mutation.
 
 Let's look at two additional methods provided by the cache to enable
 updates.
 
-The first one is named `updateQuery`, this method given a query and a result updates
-the cache.
+The first we'll look at is `updateQuery`. This method, given a query and a result,
+updates the cache.
 
 ```js
 const Todos = gql`
@@ -30,7 +30,7 @@ const Todos = gql`
 cache.updateQuery(Todos, data => {
   data.todos.push({
     id: '2',
-    text: 'Learn updates and queryResolvers',
+    text: 'Learn updates and resolvers',
     complete: false,
     __typename: 'Todo',
   });
@@ -38,16 +38,18 @@ cache.updateQuery(Todos, data => {
 });
 ```
 
-So how to interpret the above code-sample, we supply a query
-to the cache, this way it can fetch the required data. Then it
-will call your second argument with the data it has queried, you
-can now alter this and return it. When you have returned to the
-cache it will update the relevant query with your given input.
+In the above code sample, we start by supplying a query to the `cache`.
+This allows it to fetch the required data. This data is passed as the
+second argument to the `updater`, which allows you to alter it before
+returning. When you have returned to the cache it will update the relevant
+query with your given input.
 
 > Note that you have to supply \_\_typename.
 
-Secondly we have `updateFragment`, this method is mainly meant so
-you don't have to supply the full object every time.
+The second method we have available on the `cache` is `updateFragment`.
+This method allows you to supply a GraphQL fragment to update, such that you
+don't have to supply the full object entity (in this case `Todo`) if you just
+want to update specific fields.
 
 ```js
 cache.updateFragment(
@@ -64,10 +66,11 @@ cache.updateFragment(
 );
 ```
 
-The way to read this is, we supply a partial `Todo` having `id` or `_id`
-so we know what entity you are telling the cache to update and some fields
-you want to update. So in this case we update id "1" to have text "update".
-The rest of the properties (complete and \_\_typename) will stay untouched.
+In the example above, we supply a fragment on `Todo` to `updateFragment`. You'll
+notice we include the `id` property such that the cache knows which entity to update,
+as well as the some fields we want to update. So in this case we update `Todo` with `id`
+`'1'` to have text `'update'`. The rest of the properties (complete and \_\_typename)
+will stay untouched.
 
 ```js
 const cache = cacheExchange({


### PR DESCRIPTION
This PR simply adds some clarifying language to the docs. They're mostly just grammatical changes that I felt made things more readable while studying the cache at React Rally on Friday. I don't think there are any conflicts with #41, but we should merge that first and I can handle any discrepancies that come up. Also, let me know if you both feel these changes _don't_ make the docs more readable, or if they aren't true to the behavior of the graphcache. I'm still working to understand the code, so let me know if anything feels really off. Excited to keep studying and learning from this, love the support for optimistic updates and the `updateFragment` API in particular :chefs-kiss: