### PR TITLE
Use mutable/immutable switching for pessimism

### DIFF
--- a/src/operations/query.ts
+++ b/src/operations/query.ts
@@ -47,10 +47,9 @@ interface Context {
 
 /** Reads a request entirely from the store */
 export const query = (store: Store, request: OperationRequest): QueryResult => {
-  initStoreState(0);
-
+  initStoreState(store, 0);
   const result = startQuery(store, request);
-  clearStoreState();
+  clearStoreState(store);
   return result;
 };
 

--- a/src/operations/write.ts
+++ b/src/operations/write.ts
@@ -52,12 +52,9 @@ export const write = (
   request: OperationRequest,
   data: Data
 ): WriteResult => {
-  initStoreState(0);
-
+  initStoreState(store, 0);
   const result = startWrite(store, request, data);
-
-  clearStoreState();
-
+  clearStoreState(store);
   return result;
 };
 
@@ -93,7 +90,7 @@ export const writeOptimistic = (
   request: OperationRequest,
   optimisticKey: number
 ): WriteResult => {
-  initStoreState(optimisticKey);
+  initStoreState(store, optimisticKey);
 
   const operation = getMainOperation(request.query);
   const result: WriteResult = { dependencies: getCurrentDependencies() };
@@ -124,7 +121,7 @@ export const writeOptimistic = (
     });
   }
 
-  clearStoreState();
+  clearStoreState(store);
   return result;
 };
 

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -80,7 +80,7 @@ describe('Store with OptimisticMutationConfig', () => {
       ],
     };
     write(store, { query: Todos }, todosData);
-    initStoreState(null);
+    initStoreState(store, null);
   });
 
   it('Should resolve a property', () => {
@@ -96,7 +96,7 @@ describe('Store with OptimisticMutationConfig', () => {
     // TODO: we have no way of asserting this to really be the case.
     const deps = getCurrentDependencies();
     expect(deps).toEqual(new Set(['Todo:0', 'Author:0']));
-    clearStoreState();
+    clearStoreState(store);
   });
 
   it('should resolve witha key as first argument', () => {
@@ -104,7 +104,7 @@ describe('Store with OptimisticMutationConfig', () => {
     expect(authorResult).toBe('Jovi');
     const deps = getCurrentDependencies();
     expect(deps).toEqual(new Set(['Author:0']));
-    clearStoreState();
+    clearStoreState(store);
   });
 
   it('Should resolve a link property', () => {
@@ -118,11 +118,11 @@ describe('Store with OptimisticMutationConfig', () => {
     expect(result).toEqual('Author:0');
     const deps = getCurrentDependencies();
     expect(deps).toEqual(new Set(['Todo:0']));
-    clearStoreState();
+    clearStoreState(store);
   });
 
   it('should be able to update a fragment', () => {
-    initStoreState(0);
+    initStoreState(store, 0);
     store.writeFragment(
       gql`
         fragment _ on Todo {
@@ -155,11 +155,11 @@ describe('Store with OptimisticMutationConfig', () => {
         todosData.todos[2],
       ],
     });
-    clearStoreState();
+    clearStoreState(store);
   });
 
   it('should be able to update a query', () => {
-    initStoreState(0);
+    initStoreState(store, 0);
     store.updateQuery(Todos, data => ({
       ...data,
       todos: [
@@ -176,7 +176,7 @@ describe('Store with OptimisticMutationConfig', () => {
         },
       ],
     }));
-    clearStoreState();
+    clearStoreState(store);
 
     const { data: result } = query(store, { query: Todos });
     expect(result).toEqual({
@@ -195,7 +195,7 @@ describe('Store with OptimisticMutationConfig', () => {
         },
       ],
     });
-    clearStoreState();
+    clearStoreState(store);
   });
 
   it('should be able to optimistically mutate', () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -38,13 +38,17 @@ const refValue = <T>(ref: Ref<T>): T => {
 };
 
 // Initialise a store run by resetting its internal state
-export const initStoreState = (optimisticKey: null | number) => {
+export const initStoreState = (store: Store, optimisticKey: null | number) => {
+  store.records = Pessimism.asMutable(store.records);
+  store.links = Pessimism.asMutable(store.links);
   currentDependencies.current = new Set();
   currentOptimisticKey.current = optimisticKey;
 };
 
 // Finalise a store run by clearing its internal state
-export const clearStoreState = () => {
+export const clearStoreState = (store: Store) => {
+  store.records = Pessimism.asImmutable(store.records);
+  store.links = Pessimism.asImmutable(store.links);
   currentDependencies.current = null;
   currentOptimisticKey.current = null;
 };
@@ -84,8 +88,8 @@ export class Store {
     optimisticMutations?: OptimisticMutationConfig,
     keys?: KeyingConfig
   ) {
-    this.records = Pessimism.asMutable(Pessimism.make());
-    this.links = Pessimism.asMutable(Pessimism.make());
+    this.records = Pessimism.make();
+    this.links = Pessimism.make();
     this.resolvers = resolvers || {};
     this.updates = {
       Mutation: (updates && updates.Mutation) || {},


### PR DESCRIPTION
This makes full use of Pessimism's asMutable
and asImmutable. This means that after each
operation we have new sets of references of maps,
but during operations we write transitively.

(We don't yet need this so there's no need to merge this yet)