### PR TITLE
(fix) - query the data after writing to respect our resolvers

### DIFF
--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -187,17 +187,20 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
   // Take any OperationResult and update the cache with it
   const updateCacheWithResult = (result: OperationResult) => {
     const { data, operation } = result;
-    let dependencies;
-    if (data !== null && data !== undefined) {
-      dependencies = write(store, operation, data).dependencies;
-      result.data = query(store, operation).data;
-    }
 
     // Clear old optimistic values from the store
     const { key } = operation;
     if (optimisticKeys.has(key)) {
       optimisticKeys.delete(key);
       store.clearOptimistic(key);
+    }
+
+    let dependencies;
+    if (data !== null && data !== undefined) {
+      dependencies = write(store, operation, data).dependencies;
+      if (isQueryOperation(operation)) {
+        result.data = query(store, operation).data;
+      }
     }
 
     if (dependencies !== undefined) {

--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -17,7 +17,9 @@ import {
   ResolverConfig,
   OptimisticMutationConfig,
   KeyingConfig,
+  Data,
 } from './types';
+import { resolveData } from './operations/resolve';
 
 type OperationResultWithMeta = OperationResult & {
   completeness: Completeness;
@@ -175,6 +177,7 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
     const isComplete = policy === 'cache-only' || res.completeness === 'FULL';
     if (isComplete) {
       updateDependencies(operation, res.dependencies);
+      resolveData(store, operation, res.data as Data);
     }
 
     return {
@@ -199,7 +202,7 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
     if (data !== null && data !== undefined) {
       dependencies = write(store, operation, data).dependencies;
       if (isQueryOperation(operation)) {
-        result.data = query(store, operation).data;
+        result.data = resolveData(store, operation, data);
       }
     }
 

--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -185,10 +185,12 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
   };
 
   // Take any OperationResult and update the cache with it
-  const updateCacheWithResult = ({ data, operation }: OperationResult) => {
+  const updateCacheWithResult = (result: OperationResult) => {
+    const { data, operation } = result;
     let dependencies;
     if (data !== null && data !== undefined) {
       dependencies = write(store, operation, data).dependencies;
+      result.data = query(store, operation).data;
     }
 
     // Clear old optimistic values from the store

--- a/src/helpers/keys.ts
+++ b/src/helpers/keys.ts
@@ -1,6 +1,12 @@
 import stringify from 'fast-json-stable-stringify';
 import { Variables, KeyGenerator, Data } from '../types';
 
+export const isDataOrKey = (x: any): x is string | Data =>
+  typeof x === 'string' ||
+  (typeof x === 'object' &&
+    x !== null &&
+    typeof (x as any).__typename === 'string');
+
 export const keyOfEntity: KeyGenerator = (data: Data): null | string => {
   const { __typename: typeName } = data;
   const id = data.id === undefined ? data._id : data.id;

--- a/src/operations/query.ts
+++ b/src/operations/query.ts
@@ -1,5 +1,3 @@
-import warning from 'warning';
-
 import {
   getFragments,
   getMainOperation,
@@ -14,7 +12,6 @@ import {
   Fragments,
   Variables,
   Data,
-  DataField,
   Link,
   SelectionSet,
   Completeness,
@@ -107,35 +104,7 @@ const readSelection = (
 
     if (isQuery) addDependency(fieldKey);
 
-    const resolvers = store.resolvers[typename];
-    if (resolvers !== undefined && resolvers.hasOwnProperty(fieldName)) {
-      // We have a resolver for this field.
-      const resolverValue = resolvers[fieldName](
-        data,
-        fieldArgs || {},
-        store,
-        ctx
-      );
-
-      if (node.selectionSet === undefined) {
-        // If it doesn't have a selection set we have resolved a property.
-        // We assume that a resolver for scalar values implies that this
-        // field is always present, so completeness won't be set to EMPTY here
-        data[fieldAlias] = resolverValue !== undefined ? resolverValue : null;
-      } else {
-        // When it has a selection set we are resolving an entity with a
-        // subselection. This can either be a list or an object.
-        const fieldSelect = getSelectionSet(node);
-
-        data[fieldAlias] = resolveResolverResult(
-          ctx,
-          resolverValue,
-          fieldKey,
-          fieldSelect,
-          data[fieldAlias] as Data | Data[]
-        );
-      }
-    } else if (node.selectionSet === undefined) {
+    if (node.selectionSet === undefined) {
       // The field is a scalar and can be retrieved directly
       if (fieldValue === undefined) {
         // Cache Incomplete: A missing field means it wasn't cached
@@ -169,55 +138,6 @@ const readSelection = (
   return data;
 };
 
-const resolveResolverResult = (
-  ctx: Context,
-  result: DataField,
-  key: string,
-  select: SelectionSet,
-  prevData: void | Data | Data[]
-) => {
-  // When we are dealing with a list we have to call this method again.
-  if (Array.isArray(result)) {
-    // @ts-ignore: Link cannot be expressed as a recursive type
-    return result.map((childResult, index) => {
-      const data = prevData !== undefined ? prevData[index] : undefined;
-      const indexKey = joinKeys(key, `${index}`);
-      return resolveResolverResult(ctx, childResult, indexKey, select, data);
-    });
-  } else if (result === null) {
-    return null;
-  } else if (isDataOrKey(result)) {
-    // We don't need to read the entity after exiting a resolver
-    // we can just go on and read the selection further.
-    const data = prevData === undefined ? Object.create(null) : prevData;
-    const childKey =
-      (typeof result === 'string' ? result : ctx.store.keyOfEntity(result)) ||
-      key;
-    const selectionResult = readSelection(ctx, childKey, select, data);
-
-    if (selectionResult !== null && typeof result === 'object') {
-      for (key in result) {
-        if (key !== '__typename' && result.hasOwnProperty(key)) {
-          selectionResult[key] = result[key];
-        }
-      }
-    }
-
-    return selectionResult;
-  }
-
-  warning(
-    false,
-    'Invalid resolver value: The resolver at `%s` returned a scalar (number, boolean, etc)' +
-      ', but the GraphQL query expects a selection set for this field.\n' +
-      'If necessary, use Cache.resolve() to resolve a link or entity from the cache.',
-    key
-  );
-
-  ctx.result.completeness = 'EMPTY';
-  return null;
-};
-
 const resolveLink = (
   ctx: Context,
   link: Link | Link[],
@@ -239,9 +159,3 @@ const resolveLink = (
     return readSelection(ctx, link, select, data);
   }
 };
-
-const isDataOrKey = (x: any): x is string | Data =>
-  typeof x === 'string' ||
-  (typeof x === 'object' &&
-    x !== null &&
-    typeof (x as any).__typename === 'string');

--- a/src/operations/resolve.ts
+++ b/src/operations/resolve.ts
@@ -144,7 +144,12 @@ const resolveDataSelection = (
           const childLink = link[i];
           if (childLink !== null) {
             // @ts-ignore
-            resolveDataSelection(ctx, childLink, fieldSelect, data[fieldAlias]);
+            resolveDataSelection(
+              ctx,
+              childLink,
+              fieldSelect,
+              data[fieldAlias][i]
+            );
           }
         }
       } else if (typeof link === 'string') {

--- a/src/operations/resolve.ts
+++ b/src/operations/resolve.ts
@@ -1,0 +1,138 @@
+import { Store } from '../store';
+import {
+  Data,
+  SelectionSet,
+  OperationRequest,
+  Variables,
+  Fragments,
+  DataField,
+} from '../types';
+import {
+  getSelectionSet,
+  getMainOperation,
+  normalizeVariables,
+  getFragments,
+  getName,
+  getFieldArguments,
+  getFieldAlias,
+} from '../ast';
+import { SelectionIterator } from './shared';
+import { joinKeys, keyOfField, isDataOrKey } from '../helpers';
+import warning from 'warning';
+
+interface Context {
+  store: Store;
+  variables: Variables;
+  fragments: Fragments;
+}
+
+export const resolveData = (
+  store: Store,
+  request: OperationRequest,
+  data: Data
+) => {
+  const operation = getMainOperation(request.query);
+  const ctx = {
+    store,
+    variables: normalizeVariables(operation, request.variables),
+    fragments: getFragments(request.query),
+  };
+  resolveDataSelection(ctx, 'Query', getSelectionSet(operation), data);
+  return data;
+};
+
+const resolveResolverResult = (
+  ctx: Context,
+  result: DataField,
+  key: string,
+  select: SelectionSet,
+  prevData: void | Data | Data[]
+) => {
+  // When we are dealing with a list we have to call this method again.
+  if (Array.isArray(result)) {
+    // @ts-ignore: Link cannot be expressed as a recursive type
+    return result.map((childResult, index) => {
+      const data = prevData !== undefined ? prevData[index] : undefined;
+      const indexKey = joinKeys(key, `${index}`);
+      return resolveResolverResult(ctx, childResult, indexKey, select, data);
+    });
+  } else if (result === null) {
+    return null;
+  } else if (isDataOrKey(result)) {
+    // We don't need to read the entity after exiting a resolver
+    // we can just go on and read the selection further.
+    const data = prevData === undefined ? Object.create(null) : prevData;
+    const childKey =
+      (typeof result === 'string' ? result : ctx.store.keyOfEntity(result)) ||
+      key;
+    const selectionResult = resolveDataSelection(ctx, childKey, select, data);
+
+    if (selectionResult !== null && typeof result === 'object') {
+      for (key in result) {
+        if (key !== '__typename' && result.hasOwnProperty(key)) {
+          selectionResult[key] = result[key];
+        }
+      }
+    }
+
+    return selectionResult;
+  }
+
+  warning(
+    false,
+    'Invalid resolver value: The resolver at `%s` returned a scalar (number, boolean, etc)' +
+      ', but the GraphQL query expects a selection set for this field.\n' +
+      'If necessary, use Cache.resolve() to resolve a link or entity from the cache.',
+    key
+  );
+
+  return null;
+};
+
+const resolveDataSelection = (
+  ctx: Context,
+  entityKey: string,
+  select: SelectionSet,
+  data: Data
+) => {
+  const { store, variables } = ctx;
+  const typename =
+    entityKey === 'Query'
+      ? entityKey
+      : (store.getField(entityKey, '__typename') as string);
+  const iter = new SelectionIterator(typename, entityKey, select, ctx);
+
+  let node;
+  while ((node = iter.next()) !== undefined) {
+    // Derive the needed data from our node.
+    const fieldName = getName(node);
+    const fieldArgs = getFieldArguments(node, variables);
+    const fieldAlias = getFieldAlias(node);
+    const fieldKey = joinKeys(entityKey, keyOfField(fieldName, fieldArgs));
+
+    const resolvers = store.resolvers[typename];
+    if (resolvers !== undefined && resolvers.hasOwnProperty(fieldName)) {
+      // We have a resolver for this field.
+      const resolverValue = resolvers[fieldName](
+        data,
+        fieldArgs || {},
+        store,
+        ctx
+      );
+
+      if (node.selectionSet === undefined) {
+        data[fieldAlias] = resolverValue !== undefined ? resolverValue : null;
+      } else {
+        const fieldSelect = getSelectionSet(node);
+
+        data[fieldAlias] = resolveResolverResult(
+          ctx,
+          resolverValue,
+          fieldKey,
+          fieldSelect,
+          data[fieldAlias] as Data | Data[]
+        );
+      }
+    }
+  }
+};

--- a/src/operations/resolve.ts
+++ b/src/operations/resolve.ts
@@ -37,6 +37,7 @@ export const resolveData = (
     variables: normalizeVariables(operation, request.variables),
     fragments: getFragments(request.query),
   };
+
   resolveDataSelection(ctx, 'Query', getSelectionSet(operation), data);
   return data;
 };
@@ -100,6 +101,7 @@ const resolveDataSelection = (
     entityKey === 'Query'
       ? entityKey
       : (store.getField(entityKey, '__typename') as string);
+
   const iter = new SelectionIterator(typename, entityKey, select, ctx);
 
   let node;
@@ -132,6 +134,22 @@ const resolveDataSelection = (
           fieldSelect,
           data[fieldAlias] as Data | Data[]
         );
+      }
+    } else if (node.selectionSet !== undefined) {
+      const fieldSelect = getSelectionSet(node);
+      const link = store.getLink(fieldKey);
+
+      if (Array.isArray(link)) {
+        for (let i = 0, l = link.length; i < l; i++) {
+          const childLink = link[i];
+          if (childLink !== null) {
+            // @ts-ignore
+            resolveDataSelection(ctx, childLink, fieldSelect, data[fieldAlias]);
+          }
+        }
+      } else if (typeof link === 'string') {
+        // @ts-ignore
+        resolveDataSelection(ctx, link, fieldSelect, data[fieldAlias]);
       }
     }
   }

--- a/src/operations/resolve.ts
+++ b/src/operations/resolve.ts
@@ -143,18 +143,16 @@ const resolveDataSelection = (
         for (let i = 0, l = link.length; i < l; i++) {
           const childLink = link[i];
           if (childLink !== null) {
-            // @ts-ignore
             resolveDataSelection(
               ctx,
               childLink,
               fieldSelect,
-              data[fieldAlias][i]
+              (data[fieldAlias] as Data[])[i]
             );
           }
         }
       } else if (typeof link === 'string') {
-        // @ts-ignore
-        resolveDataSelection(ctx, link, fieldSelect, data[fieldAlias]);
+        resolveDataSelection(ctx, link, fieldSelect, data[fieldAlias] as Data);
       }
     }
   }

--- a/src/test-utils/examples-1.test.ts
+++ b/src/test-utils/examples-1.test.ts
@@ -116,65 +116,7 @@ it('passes the "getting-started" example', () => {
   });
 });
 
-it('respects property-level resolvers when given', () => {
-  const store = new Store({ Todo: { text: () => 'hi' } });
-  const todosData = {
-    __typename: 'Query',
-    todos: [
-      { id: '0', text: 'Go to the shops', complete: false, __typename: 'Todo' },
-      { id: '1', text: 'Pick up the kids', complete: true, __typename: 'Todo' },
-      { id: '2', text: 'Install urql', complete: false, __typename: 'Todo' },
-    ],
-  };
-
-  const writeRes = write(store, { query: Todos }, todosData);
-
-  const expectedSet = new Set(['Query.todos', 'Todo:0', 'Todo:1', 'Todo:2']);
-  expect(writeRes.dependencies).toEqual(expectedSet);
-
-  let queryRes = query(store, { query: Todos });
-
-  expect(queryRes.data).toEqual({
-    __typename: 'Query',
-    todos: [
-      { id: '0', text: 'hi', complete: false, __typename: 'Todo' },
-      { id: '1', text: 'hi', complete: true, __typename: 'Todo' },
-      { id: '2', text: 'hi', complete: false, __typename: 'Todo' },
-    ],
-  });
-  expect(queryRes.dependencies).toEqual(writeRes.dependencies);
-  expect(queryRes.completeness).toBe('FULL');
-
-  const mutatedTodo = {
-    ...todosData.todos[2],
-    complete: true,
-  };
-
-  const mutationRes = write(
-    store,
-    { query: ToggleTodo, variables: { id: '2' } },
-    {
-      __typename: 'Mutation',
-      toggleTodo: mutatedTodo,
-    }
-  );
-
-  expect(mutationRes.dependencies).toEqual(new Set(['Todo:2']));
-
-  queryRes = query(store, { query: Todos });
-
-  expect(queryRes.completeness).toBe('FULL');
-  expect(queryRes.data).toEqual({
-    ...todosData,
-    todos: [
-      { id: '0', text: 'hi', complete: false, __typename: 'Todo' },
-      { id: '1', text: 'hi', complete: true, __typename: 'Todo' },
-      { id: '2', text: 'hi', complete: true, __typename: 'Todo' },
-    ],
-  });
-});
-
-it('Respects property-level resolvers when given', () => {
+it('Follows given update functions for a Mutation', () => {
   const store = new Store(undefined, {
     Mutation: {
       toggleTodo: function toggleTodo(result, _, cache) {


### PR DESCRIPTION
This refactor allows us to do a few things.

After the first write it will respect resolvers when they are present.
It will also execute resolvers after all data has been queried, this allows the user to format a date with the current data instead of having to do this in a separate field.

The only failing test for now is one that relies on resolvers being executed in `query`