### PR TITLE
(feat) - include current value in resolver

### DIFF
--- a/src/exchange.test.ts
+++ b/src/exchange.test.ts
@@ -555,18 +555,21 @@ it('follows nested resolvers for mutations', () => {
     );
 
   const fakeResolver = jest.fn();
+  const called: any[] = [];
 
   pipe(
     cacheExchange({
       resolvers: {
         Author: {
-          name: () => {
+          name: parent => {
+            called.push(parent.name);
             fakeResolver();
             return 'Secret Author';
           },
         },
         Book: {
-          title: () => {
+          title: parent => {
+            called.push(parent.title);
             fakeResolver();
             return 'Secret Book';
           },
@@ -607,4 +610,15 @@ it('follows nested resolvers for mutations', () => {
       },
     ],
   });
+
+  expect(called).toEqual([
+    // Query
+    '[REDACTED ONLINE]',
+    'Formidable',
+    'AwesomeGQL',
+    // Mutation
+    '[REDACTED ONLINE]',
+    'Formidable',
+    'AwesomeGQL',
+  ]);
 });

--- a/src/operations/query.ts
+++ b/src/operations/query.ts
@@ -205,6 +205,9 @@ const readSelection = (
     const resolvers = store.resolvers[typename];
     if (resolvers !== undefined && resolvers.hasOwnProperty(fieldName)) {
       // We have a resolver for this field.
+      if (fieldValue !== undefined) {
+        data[fieldAlias] = fieldValue;
+      }
       const resolverValue = resolvers[fieldName](
         data,
         fieldArgs || {},


### PR DESCRIPTION
I've been thinking about our conversation from Friday where we saw this as an inconvenience, I think for the time being we can easily solve this problem by including the value that we get from the store anyway in our resolver.

What do you think about this?
This would ensure that when we are resolving that the current value for example the date we want to format is available on the parent. For every other need  people can use `store.resolve`