### PR TITLE
Refactor queries to allow for cascaded partial results

### DIFF
--- a/src/ast/schemaPredicates.ts
+++ b/src/ast/schemaPredicates.ts
@@ -21,70 +21,14 @@ export class SchemaPredicates {
   }
 
   isFieldNullable(typename: string, fieldName: string): boolean {
-    const type = this.schema.getType(typename);
-    expectObjectType(type, typename);
-
-    const object = type as GraphQLObjectType;
-    if (object === undefined) {
-      warning(
-        false,
-        'Invalid type: The type `%s` is not a type in the defined schema, ' +
-          'but the GraphQL document expects it to exist.\n' +
-          'Traversal will continue, however this may lead to undefined behavior!',
-        typename
-      );
-
-      return false;
-    }
-
-    const field = object.getFields()[fieldName];
-    if (field === undefined) {
-      warning(
-        false,
-        'Invalid field: The field `%s` does not exist on `%s`, ' +
-          'but the GraphQL document expects it to exist.\n' +
-          'Traversal will continue, however this may lead to undefined behavior!',
-        fieldName,
-        typename
-      );
-
-      return false;
-    }
-
+    const field = getField(this.schema, typename, fieldName);
+    if (field === undefined) return false;
     return isNullableType(field.type);
   }
 
   isListNullable(typename: string, fieldName: string): boolean {
-    const type = this.schema.getType(typename);
-    expectObjectType(type, typename);
-
-    const object = type as GraphQLObjectType;
-    if (object === undefined) {
-      warning(
-        false,
-        'Invalid type: The type `%s` is not a type in the defined schema, ' +
-          'but the GraphQL document expects it to exist.\n' +
-          'Traversal will continue, however this may lead to undefined behavior!',
-        typename
-      );
-
-      return false;
-    }
-
-    const field = object.getFields()[fieldName];
-    if (field === undefined) {
-      warning(
-        false,
-        'Invalid field: The field `%s` does not exist on `%s`, ' +
-          'but the GraphQL document expects it to exist.\n' +
-          'Traversal will continue, however this may lead to undefined behavior!',
-        fieldName,
-        typename
-      );
-
-      return false;
-    }
-
+    const field = getField(this.schema, typename, fieldName);
+    if (field === undefined) return false;
     const ofType = isNonNullType(field.type) ? field.type.ofType : field.type;
     return isListType(ofType) && isNullableType(ofType.ofType);
   }
@@ -106,6 +50,44 @@ export class SchemaPredicates {
     return this.schema.isPossibleType(abstractNode, concreteNode);
   }
 }
+
+const getField = (
+  schema: GraphQLSchema,
+  typename: string,
+  fieldName: string
+) => {
+  const type = schema.getType(typename);
+  expectObjectType(type, typename);
+
+  const object = type as GraphQLObjectType;
+  if (object === undefined) {
+    warning(
+      false,
+      'Invalid type: The type `%s` is not a type in the defined schema, ' +
+        'but the GraphQL document expects it to exist.\n' +
+        'Traversal will continue, however this may lead to undefined behavior!',
+      typename
+    );
+
+    return undefined;
+  }
+
+  const field = object.getFields()[fieldName];
+  if (field === undefined) {
+    warning(
+      false,
+      'Invalid field: The field `%s` does not exist on `%s`, ' +
+        'but the GraphQL document expects it to exist.\n' +
+        'Traversal will continue, however this may lead to undefined behavior!',
+      fieldName,
+      typename
+    );
+
+    return undefined;
+  }
+
+  return field;
+};
 
 const expectObjectType = (type: any, typename: string) => {
   invariant(

--- a/src/exchange.test.ts
+++ b/src/exchange.test.ts
@@ -497,6 +497,7 @@ it('follows nested resolvers for mutations', () => {
       {
         __typename: 'Author',
         id: '123',
+        book: null,
         name: '[REDACTED ONLINE]',
       },
       {
@@ -537,8 +538,7 @@ it('follows nested resolvers for mutations', () => {
     (forwardOp: Operation): OperationResult => {
       if (forwardOp.key === 1) {
         return { operation: queryOperation, data: queryData };
-      }
-      if (forwardOp.key === 2) {
+      } else if (forwardOp.key === 2) {
         return { operation: mutationOperation, data: mutationData };
       }
 

--- a/src/exchange.test.ts
+++ b/src/exchange.test.ts
@@ -520,6 +520,7 @@ it('follows nested resolvers for mutations', () => {
         __typename: 'Author',
         id: '123',
         name: '[REDACTED ONLINE]',
+        book: null,
       },
       {
         __typename: 'Author',

--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -8,7 +8,7 @@ import {
 } from 'urql';
 
 import { filter, map, merge, pipe, share, tap } from 'wonka';
-import { query, write, writeOptimistic, readOperation } from './operations';
+import { query, write, writeOptimistic } from './operations';
 import { Store } from './store';
 
 import {
@@ -217,7 +217,7 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
         data = queryResult.data;
         queryDependencies = queryResult.dependencies;
       } else {
-        data = readOperation(store, operation, data).data;
+        data = query(store, operation, data).data;
       }
     }
 

--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -177,7 +177,7 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
       cacheOutcome = 'miss';
     } else {
       updateDependencies(operation, dependencies);
-      cacheOutcome = partial || policy === 'cache-only' ? 'hit' : 'partial';
+      cacheOutcome = !partial || policy === 'cache-only' ? 'hit' : 'partial';
     }
 
     return {

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -1,2 +1,2 @@
-export { query } from './query';
+export { query, read } from './query';
 export { write, writeOptimistic, writeFragment } from './write';

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -1,2 +1,2 @@
-export { query, readOperation } from './query';
+export { query } from './query';
 export { write, writeOptimistic, writeFragment } from './write';

--- a/src/operations/query.test.ts
+++ b/src/operations/query.test.ts
@@ -45,7 +45,7 @@ describe('Query', () => {
 
   it('test partial results', () => {
     const result = query(store, { query: TODO_QUERY });
-    expect(result.completeness).toEqual('PARTIAL');
+    expect(result.partial).toBe(true);
     expect(result.data).toEqual({
       __typename: 'Query',
       todos: [

--- a/src/operations/query.test.ts
+++ b/src/operations/query.test.ts
@@ -43,7 +43,7 @@ describe('Query', () => {
     );
   });
 
-  it('test partial results', () => {
+  it.only('test partial results', () => {
     const result = query(store, { query: TODO_QUERY });
     expect(result.partial).toBe(true);
     expect(result.data).toEqual({

--- a/src/operations/query.test.ts
+++ b/src/operations/query.test.ts
@@ -43,7 +43,7 @@ describe('Query', () => {
     );
   });
 
-  it.only('test partial results', () => {
+  it('test partial results', () => {
     const result = query(store, { query: TODO_QUERY });
     expect(result.partial).toBe(true);
     expect(result.data).toEqual({

--- a/src/operations/query.ts
+++ b/src/operations/query.ts
@@ -234,25 +234,24 @@ const readSelection = (
       }
     }
 
-    // When dataFieldValue is undefined that means that we have to check whether we can continue,
-    // or whether this Data is now invalid, in which case we return undefined
-    if (schemaPredicates !== undefined) {
-      // If we can check against the schema an uncached field may be acceptable for partial results
-      if (
-        dataFieldValue === undefined &&
-        schemaPredicates.isFieldNullable(typename, fieldName)
-      ) {
-        hasFields = true;
-        data[fieldAlias] = null;
-        ctx.partial = true;
-      } else {
-        return undefined;
-      }
+    // Now that dataFieldValue has been retrieved it'll be set on data
+    // If it's uncached (undefined) but nullable we can continue assembling
+    // a partial query result
+    if (
+      dataFieldValue === undefined &&
+      schemaPredicates !== undefined &&
+      schemaPredicates.isFieldNullable(typename, fieldName)
+    ) {
+      // The field is uncached but we have a schema that says it's nullable
+      // Set the field to null and continue
+      hasFields = true;
+      data[fieldAlias] = null;
+      ctx.partial = true;
     } else if (dataFieldValue === undefined) {
-      // Otherwise an uncached field means that the Data is invalid, so we return undefined
+      // The field is uncached and not nullable; return undefined
       return undefined;
     } else {
-      // Otherwise we can set the field on data and continue
+      // Otherwise continue as usual
       hasFields = true;
       data[fieldAlias] = dataFieldValue;
     }

--- a/src/operations/query.ts
+++ b/src/operations/query.ts
@@ -17,7 +17,6 @@ import {
   DataField,
   Link,
   SelectionSet,
-  Completeness,
   OperationRequest,
   NullArray,
 } from '../types';
@@ -35,90 +34,60 @@ import { joinKeys, keyOfField } from '../helpers';
 import { SchemaPredicates } from '../ast/schemaPredicates';
 
 export interface QueryResult {
-  completeness: Completeness;
   dependencies: Set<string>;
+  partial: boolean;
   data: null | Data;
 }
 
 interface Context {
-  result: QueryResult;
+  partial: boolean;
   store: Store;
   variables: Variables;
   fragments: Fragments;
   schemaPredicates?: SchemaPredicates;
 }
 
-/** Reads a request entirely from the store */
-export const query = (store: Store, request: OperationRequest): QueryResult => {
-  initStoreState(0);
-
-  const result = startQuery(store, request);
-  clearStoreState();
-  return result;
-};
-
-export const startQuery = (store: Store, request: OperationRequest) => {
-  const operation = getMainOperation(request.query);
-  const root: Data = Object.create(null);
-  const result: QueryResult = {
-    completeness: 'FULL',
-    dependencies: getCurrentDependencies(),
-    data: root,
-  };
-
-  const ctx: Context = {
-    variables: normalizeVariables(operation, request.variables),
-    fragments: getFragments(request.query),
-    result,
-    store,
-    schemaPredicates: store.schemaPredicates,
-  };
-
-  result.data = readSelection(
-    ctx,
-    ctx.store.getRootKey('query'),
-    getSelectionSet(operation),
-    root
-  );
-
-  return result;
-};
-
-export const readOperation = (
+export const query = (
   store: Store,
   request: OperationRequest,
-  data: Data
-) => {
+  data?: Data
+): QueryResult => {
   initStoreState(0);
-
-  const operation = getMainOperation(request.query);
-
-  const result: QueryResult = {
-    completeness: 'FULL',
-    dependencies: getCurrentDependencies(),
-    data: null,
-  };
-
-  const ctx: Context = {
-    variables: normalizeVariables(operation, request.variables),
-    fragments: getFragments(request.query),
-    result,
-    store,
-    schemaPredicates: store.schemaPredicates,
-  };
-
-  result.data = readRoot(
-    ctx,
-    ctx.store.getRootKey(operation.operation),
-    getSelectionSet(operation),
-    data
-  );
-
+  const result = read(store, request, data);
   clearStoreState();
   return result;
 };
 
-export const readRoot = (
+const read = (
+  store: Store,
+  request: OperationRequest,
+  input?: Data
+): QueryResult => {
+  const operation = getMainOperation(request.query);
+  const rootKey = store.getRootKey(operation.operation);
+  const rootSelect = getSelectionSet(operation);
+
+  const ctx: Context = {
+    variables: normalizeVariables(operation, request.variables),
+    fragments: getFragments(request.query),
+    partial: false,
+    store,
+    schemaPredicates: store.schemaPredicates,
+  };
+
+  const data =
+    input !== undefined
+      ? readRoot(ctx, rootKey, rootSelect, input)
+      : readSelection(ctx, rootKey, rootSelect, Object.create(null));
+
+  return {
+    dependencies: getCurrentDependencies(),
+    partial: data === undefined ? false : ctx.partial,
+    data: data === undefined ? null : data,
+  };
+};
+
+const readRoot = (
   ctx: Context,
   entityKey: string,
   select: SelectionSet,
@@ -169,8 +138,11 @@ const readRootField = (
   // Write entity to key that falls back to the given parentFieldKey
   const entityKey = ctx.store.keyOfEntity(originalData);
   if (entityKey !== null) {
-    const data: Data = Object.create(null);
-    return readSelection(ctx, entityKey, select, data);
+    // We assume that since this is used for result data this can never be undefined,
+    // since the result data has already been written to the cache
+    const newData = Object.create(null);
+    const fieldValue = readSelection(ctx, entityKey, select, newData);
+    return fieldValue === undefined ? null : fieldValue;
   } else {
     const typename = originalData.__typename;
     return readRoot(ctx, typename, select, originalData);
@@ -182,7 +154,7 @@ const readSelection = (
   entityKey: string,
   select: SelectionSet,
   data: Data
-): Data | null => {
+): Data | undefined => {
   const { store, variables, schemaPredicates } = ctx;
   const isQuery = entityKey === store.getRootKey('query');
   if (!isQuery) addDependency(entityKey);
@@ -192,15 +164,13 @@ const readSelection = (
     ? store.getRootKey('query')
     : store.getField(entityKey, '__typename');
   if (typeof typename !== 'string') {
-    ctx.result.completeness = 'EMPTY';
-    return null;
+    return undefined;
   }
 
   data.__typename = typename;
   const iter = new SelectionIterator(typename, entityKey, select, ctx);
 
   let node;
-  let hasFields = false;
   while ((node = iter.next()) !== undefined) {
     // Derive the needed data from our node.
     const fieldName = getName(node);
@@ -211,10 +181,13 @@ const readSelection = (
 
     if (isQuery) addDependency(fieldKey);
 
+    // We temporarily store the data field in here, but undefined
+    // means that the value is missing from the cache
+    let dataFieldValue: void | DataField;
+
     const resolvers = store.resolvers[typename];
-    if (resolvers !== undefined && resolvers.hasOwnProperty(fieldName)) {
+    if (resolvers !== undefined && typeof resolvers[fieldName] === 'function') {
       // We have a resolver for this field.
-      hasFields = true;
       // Prepare the actual fieldValue, so that the resolver can use it
       if (fieldValue !== undefined) {
         data[fieldAlias] = fieldValue;
@@ -227,74 +200,59 @@ const readSelection = (
         ctx
       );
 
-      if (node.selectionSet === undefined) {
-        // If it doesn't have a selection set we have resolved a property.
-        // We assume that a resolver for scalar values implies that this
-        // field is always present, so completeness won't be set to EMPTY here
-        data[fieldAlias] = resolverValue !== undefined ? resolverValue : null;
+      const isNull = resolverValue === undefined || resolverValue === null;
+      // When we have a schema we check for a user's resolver whether the field is nullable
+      // Otherwise we trust the resolver and assume that it is
+      if (node.selectionSet === undefined || isNull) {
+        dataFieldValue = isNull ? undefined : resolverValue;
       } else {
         // When it has a selection set we are resolving an entity with a
         // subselection. This can either be a list or an object.
-        const fieldSelect = getSelectionSet(node);
-
-        data[fieldAlias] = resolveResolverResult(
+        dataFieldValue = resolveResolverResult(
           ctx,
           resolverValue,
           fieldKey,
-          fieldSelect,
+          getSelectionSet(node),
           data[fieldAlias] as Data | Data[]
         );
       }
     } else if (node.selectionSet === undefined) {
       // The field is a scalar and can be retrieved directly
-      if (
-        fieldValue === undefined &&
-        schemaPredicates !== undefined &&
-        schemaPredicates.isFieldNullable(typename, fieldName)
-      ) {
-        // Cache Incomplete: A missing field means it wasn't cached
-        ctx.result.completeness = 'PARTIAL';
-        data[fieldAlias] = null;
-      } else if (fieldValue === undefined) {
-        ctx.result.completeness = 'EMPTY';
-        data[fieldAlias] = null;
-      } else {
-        // Not dealing with undefined means it's a cached field
-        data[fieldAlias] = fieldValue;
-        hasFields = true;
-      }
+      dataFieldValue = fieldValue;
     } else {
-      // null values mean that a field might be linked to other entities
+      // We have a selection set which means that we'll be checking for links
       const fieldSelect = getSelectionSet(node);
       const link = store.getLink(fieldKey);
 
-      // Cache Incomplete: A missing link for a field means it's not cached
-      if (link === undefined) {
-        if (typeof fieldValue === 'object' && fieldValue !== null) {
-          // The entity on the field was invalid and can still be recovered
-          data[fieldAlias] = fieldValue;
-          hasFields = true;
-        } else if (
-          schemaPredicates !== undefined &&
-          schemaPredicates.isFieldNullable(typename, fieldName)
-        ) {
-          ctx.result.completeness = 'PARTIAL';
-          data[fieldAlias] = null;
-        } else {
-          ctx.result.completeness = 'EMPTY';
-          data[fieldAlias] = null;
-        }
-      } else {
+      if (link !== undefined) {
         const prevData = data[fieldAlias] as Data;
-        data[fieldAlias] = resolveLink(ctx, link, fieldSelect, prevData);
-        hasFields = true;
+        dataFieldValue = resolveLink(ctx, link, fieldSelect, prevData);
+      } else if (typeof fieldValue === 'object' && fieldValue !== null) {
+        // The entity on the field was invalid but can still be recovered
+        dataFieldValue = fieldValue;
       }
     }
-  }
 
-  if (isQuery && ctx.result.completeness === 'PARTIAL' && !hasFields) {
-    ctx.result.completeness = 'EMPTY';
-    return null;
+    // When dataFieldValue is undefined that means that we have to check whether we can continue,
+    // or whether this Data is now invalid, in which case we return undefined
+    if (schemaPredicates !== undefined) {
+      // If we can check against the schema an uncached field may be acceptable for partial results
+      if (
+        dataFieldValue === undefined &&
+        schemaPredicates.isFieldNullable(typename, fieldName)
+      ) {
+        data[fieldAlias] = null;
+        ctx.partial = true;
+      } else {
+        return undefined;
+      }
+    } else if (dataFieldValue === undefined) {
+      // Otherwise an uncached field means that the Data is invalid, so we return undefined
+      return undefined;
+    } else {
+      // Otherwise we can set the field on data and continue
+      data[fieldAlias] = dataFieldValue;
+    }
   }
 
   return data;
@@ -306,13 +264,15 @@ const resolveResolverResult = (
   key: string,
   select: SelectionSet,
   prevData: void | Data | Data[]
-) => {
+): DataField | undefined => {
   // When we are dealing with a list we have to call this method again.
   if (Array.isArray(result)) {
+    // TODO: Convert to for-loop
     // @ts-ignore: Link cannot be expressed as a recursive type
     return result.map((childResult, index) => {
       const data = prevData !== undefined ? prevData[index] : undefined;
       const indexKey = joinKeys(key, `${index}`);
+      // TODO: If SchemaPredicates.isListNullable is false we may need to return undefined for the entire list
       return resolveResolverResult(ctx, childResult, indexKey, select, data);
     });
   } else if (result === null) {
@@ -324,17 +284,8 @@ const resolveResolverResult = (
     const childKey =
       (typeof result === 'string' ? result : ctx.store.keyOfEntity(result)) ||
       key;
-    const selectionResult = readSelection(ctx, childKey, select, data);
-
-    if (selectionResult !== null && typeof result === 'object') {
-      for (key in result) {
-        if (key !== '__typename' && result.hasOwnProperty(key)) {
-          selectionResult[key] = result[key];
-        }
-      }
-    }
-
-    return selectionResult;
+    // TODO: Copy over fields from result but check against schema whether that's safe
+    return readSelection(ctx, childKey, select, data);
   }
 
   warning(
@@ -345,8 +296,7 @@ const resolveResolverResult = (
     key
   );
 
-  ctx.result.completeness = 'EMPTY';
-  return null;
+  return undefined;
 };
 
 const resolveLink = (
@@ -354,7 +304,7 @@ const resolveLink = (
   link: Link | Link[],
   select: SelectionSet,
   prevData: void | Data | Data[]
-): null | Data | Data[] => {
+): DataField | undefined => {
   if (Array.isArray(link)) {
     const newLink = new Array(link.length);
     for (let i = 0, l = link.length; i < l; i++) {
@@ -362,6 +312,7 @@ const resolveLink = (
       newLink[i] = resolveLink(ctx, link[i], select, data);
     }
 
+    // TODO: If SchemaPredicates.isListNullable is false we may need to return undefined for the entire list
     return newLink;
   } else if (link === null) {
     return null;

--- a/src/operations/query.ts
+++ b/src/operations/query.ts
@@ -201,11 +201,15 @@ const readSelection = (
         ctx
       );
 
-      const isNull = resolverValue === undefined || resolverValue === null;
-      // When we have a schema we check for a user's resolver whether the field is nullable
-      // Otherwise we trust the resolver and assume that it is
-      if (node.selectionSet === undefined || isNull) {
-        dataFieldValue = isNull ? undefined : resolverValue;
+      if (node.selectionSet === undefined) {
+        // When we have a schema we check for a user's resolver whether the field is nullable
+        // Otherwise we trust the resolver and assume that it is
+        const isNull = resolverValue === undefined || resolverValue === null;
+        if (isNull && schemaPredicates !== undefined) {
+          dataFieldValue = undefined;
+        } else {
+          dataFieldValue = isNull ? null : resolverValue;
+        }
       } else {
         // When it has a selection set we are resolving an entity with a
         // subselection. This can either be a list or an object.

--- a/src/operations/query.ts
+++ b/src/operations/query.ts
@@ -244,7 +244,6 @@ const readSelection = (
     ) {
       // The field is uncached but we have a schema that says it's nullable
       // Set the field to null and continue
-      hasFields = true;
       data[fieldAlias] = null;
       ctx.partial = true;
     } else if (dataFieldValue === undefined) {

--- a/src/operations/query.ts
+++ b/src/operations/query.ts
@@ -58,7 +58,7 @@ export const query = (
   return result;
 };
 
-const read = (
+export const read = (
   store: Store,
   request: OperationRequest,
   input?: Data

--- a/src/operations/query.ts
+++ b/src/operations/query.ts
@@ -171,6 +171,7 @@ const readSelection = (
   const iter = new SelectionIterator(typename, entityKey, select, ctx);
 
   let node;
+  let hasFields = false;
   while ((node = iter.next()) !== undefined) {
     // Derive the needed data from our node.
     const fieldName = getName(node);
@@ -241,6 +242,7 @@ const readSelection = (
         dataFieldValue === undefined &&
         schemaPredicates.isFieldNullable(typename, fieldName)
       ) {
+        hasFields = true;
         data[fieldAlias] = null;
         ctx.partial = true;
       } else {
@@ -251,11 +253,12 @@ const readSelection = (
       return undefined;
     } else {
       // Otherwise we can set the field on data and continue
+      hasFields = true;
       data[fieldAlias] = dataFieldValue;
     }
   }
 
-  return data;
+  return isQuery && ctx.partial && !hasFields ? undefined : data;
 };
 
 const resolveResolverResult = (

--- a/src/operations/query.ts
+++ b/src/operations/query.ts
@@ -75,10 +75,11 @@ export const read = (
     schemaPredicates: store.schemaPredicates,
   };
 
-  const data =
-    input !== undefined
-      ? readRoot(ctx, rootKey, rootSelect, input)
-      : readSelection(ctx, rootKey, rootSelect, Object.create(null));
+  let data = input || Object.create(null);
+  data =
+    rootKey !== 'Query'
+      ? readRoot(ctx, rootKey, rootSelect, data)
+      : readSelection(ctx, rootKey, rootSelect, data);
 
   return {
     dependencies: getCurrentDependencies(),

--- a/src/operations/query.ts
+++ b/src/operations/query.ts
@@ -172,6 +172,7 @@ const readSelection = (
 
   let node;
   let hasFields = false;
+  let hasPartials = false;
   while ((node = iter.next()) !== undefined) {
     // Derive the needed data from our node.
     const fieldName = getName(node);
@@ -248,8 +249,8 @@ const readSelection = (
     ) {
       // The field is uncached but we have a schema that says it's nullable
       // Set the field to null and continue
+      hasPartials = true;
       data[fieldAlias] = null;
-      ctx.partial = true;
     } else if (dataFieldValue === undefined) {
       // The field is uncached and not nullable; return undefined
       return undefined;
@@ -260,7 +261,8 @@ const readSelection = (
     }
   }
 
-  return isQuery && ctx.partial && !hasFields ? undefined : data;
+  if (hasPartials) ctx.partial = true;
+  return isQuery && hasPartials && !hasFields ? undefined : data;
 };
 
 const resolveResolverResult = (

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -139,7 +139,7 @@ describe('Store with OptimisticMutationConfig', () => {
     store.invalidateQuery(Todos);
     clearStoreState();
     ({ data } = query(store, { query: Todos }));
-    expect((data as any).todos).toEqual(null);
+    expect(data).toBe(null);
     expect(store.getRecord('Todo:0.text')).toBe(undefined);
   });
 
@@ -175,7 +175,7 @@ describe('Store with OptimisticMutationConfig', () => {
       query: Appointment,
       variables: { id: '1' },
     }));
-    expect((data as any).appointment).toEqual(null);
+    expect(data).toBe(null);
     expect(store.getRecord('Appointment:1.info')).toBe(undefined);
   });
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -15,7 +15,7 @@ import {
 } from './types';
 
 import { keyOfEntity, joinKeys, keyOfField } from './helpers';
-import { startQuery } from './operations/query';
+import { read } from './operations/query';
 import { writeFragment, startWrite } from './operations/write';
 import { invalidate } from './operations/invalidate';
 import { SchemaPredicates } from './ast/schemaPredicates';
@@ -211,9 +211,7 @@ export class Store {
     ctx: { query: DocumentNode; variables?: Variables },
     updater: (data: Data | null) => null | Data
   ): void {
-    const { data, completeness } = startQuery(this, ctx);
-    const input = completeness === 'EMPTY' ? null : data;
-    const output = updater(input);
+    const output = updater(read(this, ctx).data);
     if (output !== null) {
       startWrite(this, ctx, output);
     }

--- a/src/test-utils/examples-1.test.ts
+++ b/src/test-utils/examples-1.test.ts
@@ -62,7 +62,7 @@ it('passes the "getting-started" example', () => {
 
   expect(queryRes.data).toEqual(todosData);
   expect(queryRes.dependencies).toEqual(writeRes.dependencies);
-  expect(queryRes.completeness).toBe('FULL');
+  expect(queryRes.partial).toBe(false);
 
   const mutatedTodo = {
     ...todosData.todos[2],
@@ -82,7 +82,7 @@ it('passes the "getting-started" example', () => {
 
   queryRes = query(store, { query: Todos });
 
-  expect(queryRes.completeness).toBe('FULL');
+  expect(queryRes.partial).toBe(false);
   expect(queryRes.data).toEqual({
     ...todosData,
     todos: [...todosData.todos.slice(0, 2), mutatedTodo],
@@ -109,7 +109,7 @@ it('passes the "getting-started" example', () => {
 
   queryRes = query(store, { query: Todos });
 
-  expect(queryRes.completeness).toBe('FULL');
+  expect(queryRes.partial).toBe(false);
   expect(queryRes.data).toEqual({
     ...todosData,
     todos: [...todosData.todos.slice(0, 2), newMutatedTodo],
@@ -145,7 +145,7 @@ it('respects property-level resolvers when given', () => {
     ],
   });
   expect(queryRes.dependencies).toEqual(writeRes.dependencies);
-  expect(queryRes.completeness).toBe('FULL');
+  expect(queryRes.partial).toBe(false);
 
   const mutatedTodo = {
     ...todosData.todos[2],
@@ -165,7 +165,7 @@ it('respects property-level resolvers when given', () => {
 
   queryRes = query(store, { query: Todos });
 
-  expect(queryRes.completeness).toBe('FULL');
+  expect(queryRes.partial).toBe(false);
   expect(queryRes.data).toEqual({
     ...todosData,
     todos: [
@@ -248,7 +248,7 @@ it('Respects property-level resolvers when given', () => {
 
   const queryRes = query(store, { query: Todos });
 
-  expect(queryRes.completeness).toBe('FULL');
+  expect(queryRes.partial).toBe(false);
   expect(queryRes.data).toEqual({
     ...todosData,
     todos: [

--- a/src/test-utils/suite.test.ts
+++ b/src/test-utils/suite.test.ts
@@ -14,8 +14,9 @@ const expectCacheIntegrity = (testcase: TestCase) => {
   const request = { query: testcase.query, variables: testcase.variables };
   const writeRes = write(store, request, testcase.data);
   const queryRes = query(store, request);
+  expect(queryRes.data).not.toBe(null);
   expect(queryRes.data).toEqual(testcase.data);
-  expect(queryRes.completeness).toBe('FULL');
+  expect(queryRes.partial).toBe(false);
   expect(queryRes.dependencies).toEqual(writeRes.dependencies);
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,3 @@ export interface OptimisticMutationConfig {
 export interface KeyingConfig {
   [typename: string]: KeyGenerator;
 }
-
-// Completeness of the query result
-export type Completeness = 'EMPTY' | 'PARTIAL' | 'FULL';


### PR DESCRIPTION
This builds upon #58 to allow us to cascade partial results upwards. The `query` logic has been simplified so uncached values are now handled in one place and are represented by `undefined`. The `readSelection` traverser can also early-return `undefined` when non-nullable fields are missing.

This means that non-cached entries cascade upwards until we find a nullable field or hit the root. Also, early returns are now everywhere, so we don't continue walking any query that is obviously incomplete.

The non-schema-aware mode hasn't changed in behaviour and we don't have any perf regressions :+1: 

<details>
<summary>benchmark run to show that perf is the same as before</summary>

<img width="461" alt="Screenshot 2019-09-04 at 20 55 02" src="https://user-images.githubusercontent.com/2041385/64287080-aee6a900-cf56-11e9-8e46-1e9e158db360.png">

</details>