### PR TITLE
(chore) - dev warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "fast-json-stable-stringify": "^2.0.0",
     "pessimism": "^1.1.1",
     "tiny-invariant": "^1.0.6",
-    "warning": "^4.0.3",
     "wonka": "^3.2.1"
   },
   "peerDependencies": {

--- a/src/ast/schemaPredicates.ts
+++ b/src/ast/schemaPredicates.ts
@@ -1,6 +1,5 @@
 import invariant from 'invariant';
-import warning from 'warning';
-
+import { warning } from '../helpers/warning';
 import {
   buildClientSchema,
   isNullableType,
@@ -12,8 +11,6 @@ import {
   GraphQLInterfaceType,
   GraphQLUnionType,
 } from 'graphql';
-
-const warnings: { [key: string]: boolean } = {};
 
 export class SchemaPredicates {
   schema: GraphQLSchema;
@@ -68,13 +65,13 @@ const getField = (
   const object = type as GraphQLObjectType;
   if (object === undefined) {
     warning(
-      false || warnings[typename],
-      'Invalid type: The type `%s` is not a type in the defined schema, ' +
+      false,
+      'Invalid type: The type `' +
+        typename +
+        '` is not a type in the defined schema, ' +
         'but the GraphQL document expects it to exist.\n' +
-        'Traversal will continue, however this may lead to undefined behavior!',
-      typename
+        'Traversal will continue, however this may lead to undefined behavior!'
     );
-    warnings[typename] = true;
 
     return undefined;
   }
@@ -82,14 +79,15 @@ const getField = (
   const field = object.getFields()[fieldName];
   if (field === undefined) {
     warning(
-      false || warnings[`${typename}.${fieldName}`],
-      'Invalid field: The field `%s` does not exist on `%s`, ' +
+      false,
+      'Invalid field: The field `' +
+        fieldName +
+        '` does not exist on `' +
+        typename +
+        '`, ' +
         'but the GraphQL document expects it to exist.\n' +
-        'Traversal will continue, however this may lead to undefined behavior!',
-      fieldName,
-      typename
+        'Traversal will continue, however this may lead to undefined behavior!'
     );
-    warnings[`${typename}.${fieldName}`] = true;
 
     return undefined;
   }

--- a/src/helpers/warning.ts
+++ b/src/helpers/warning.ts
@@ -1,10 +1,8 @@
-import w from 'warning';
-
 const cache = {};
 
 export const warning = (clause, msg) => {
   if (!clause && !cache[msg]) {
-    w(false, msg);
+    console.error(msg);
     cache[msg] = true;
   }
 };

--- a/src/helpers/warning.ts
+++ b/src/helpers/warning.ts
@@ -1,0 +1,10 @@
+import w from 'warning';
+
+const cache = {};
+
+export const warning = (clause, msg) => {
+  if (!clause && !cache[msg]) {
+    w(false, msg);
+    cache[msg] = true;
+  }
+};

--- a/src/helpers/warning.ts
+++ b/src/helpers/warning.ts
@@ -2,7 +2,7 @@ const cache = {};
 
 export const warning = (clause, msg) => {
   if (!clause && !cache[msg]) {
-    console.error(msg);
+    console.warn(msg);
     cache[msg] = true;
   }
 };

--- a/src/operations/invalidate.test.ts
+++ b/src/operations/invalidate.test.ts
@@ -1,7 +1,7 @@
 import { Store } from '../store';
 import gql from 'graphql-tag';
 import { write } from './write';
-import { query } from './query';
+import { invalidate } from './invalidate';
 import { SchemaPredicates } from '../ast/schemaPredicates';
 
 const TODO_QUERY = gql`
@@ -49,30 +49,6 @@ describe('Query', () => {
     spy.console = jest.spyOn(console, 'error');
   });
 
-  it('test partial results', () => {
-    const result = query(store, { query: TODO_QUERY });
-    expect(result.partial).toBe(true);
-    expect(result.data).toEqual({
-      __typename: 'Query',
-      todos: [
-        {
-          id: '0',
-          text: 'Teach',
-          __typename: 'Todo',
-          author: null,
-          complete: null,
-        },
-        {
-          id: '1',
-          text: 'Learn',
-          __typename: 'Todo',
-          author: null,
-          complete: null,
-        },
-      ],
-    });
-  });
-
   it('should warn once for invalid fields on an entity', () => {
     const INVALID_TODO_QUERY = gql`
       query {
@@ -83,9 +59,9 @@ describe('Query', () => {
         }
       }
     `;
-    query(store, { query: INVALID_TODO_QUERY });
+    invalidate(store, { query: INVALID_TODO_QUERY });
     expect(console.error).toHaveBeenCalledTimes(1);
-    query(store, { query: INVALID_TODO_QUERY });
+    invalidate(store, { query: INVALID_TODO_QUERY });
     expect(console.error).toHaveBeenCalledTimes(1);
     expect((console.error as any).mock.calls[0][0]).toMatch(/incomplete/);
   });
@@ -102,9 +78,9 @@ describe('Query', () => {
         }
       }
     `;
-    query(store, { query: INVALID_TODO_QUERY });
+    invalidate(store, { query: INVALID_TODO_QUERY });
     expect(console.error).toHaveBeenCalledTimes(1);
-    query(store, { query: INVALID_TODO_QUERY });
+    invalidate(store, { query: INVALID_TODO_QUERY });
     expect(console.error).toHaveBeenCalledTimes(1);
     expect((console.error as any).mock.calls[0][0]).toMatch(/writer/);
   });

--- a/src/operations/invalidate.test.ts
+++ b/src/operations/invalidate.test.ts
@@ -46,7 +46,7 @@ describe('Query', () => {
         ],
       }
     );
-    spy.console = jest.spyOn(console, 'error');
+    spy.console = jest.spyOn(console, 'warn');
   });
 
   it('should warn once for invalid fields on an entity', () => {
@@ -60,10 +60,10 @@ describe('Query', () => {
       }
     `;
     invalidate(store, { query: INVALID_TODO_QUERY });
-    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledTimes(1);
     invalidate(store, { query: INVALID_TODO_QUERY });
-    expect(console.error).toHaveBeenCalledTimes(1);
-    expect((console.error as any).mock.calls[0][0]).toMatch(/incomplete/);
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect((console.warn as any).mock.calls[0][0]).toMatch(/incomplete/);
   });
 
   it('should warn once for invalid sub-entities on an entity', () => {
@@ -79,9 +79,9 @@ describe('Query', () => {
       }
     `;
     invalidate(store, { query: INVALID_TODO_QUERY });
-    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledTimes(1);
     invalidate(store, { query: INVALID_TODO_QUERY });
-    expect(console.error).toHaveBeenCalledTimes(1);
-    expect((console.error as any).mock.calls[0][0]).toMatch(/writer/);
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect((console.warn as any).mock.calls[0][0]).toMatch(/writer/);
   });
 });

--- a/src/operations/invalidate.ts
+++ b/src/operations/invalidate.ts
@@ -74,6 +74,10 @@ export const invalidateSelection = (
     const fieldArgs = getFieldArguments(node, variables);
     const fieldKey = joinKeys(entityKey, keyOfField(fieldName, fieldArgs));
 
+    if (process.env.NODE_ENV !== 'production' && ctx.schemaPredicates) {
+      ctx.schemaPredicates.isFieldAvailableOnType(typename, fieldName);
+    }
+
     if (isQuery) addDependency(fieldKey);
 
     if (node.selectionSet === undefined) {

--- a/src/operations/query.test.ts
+++ b/src/operations/query.test.ts
@@ -46,7 +46,7 @@ describe('Query', () => {
         ],
       }
     );
-    spy.console = jest.spyOn(console, 'error');
+    spy.console = jest.spyOn(console, 'warn');
   });
 
   it('test partial results', () => {
@@ -84,10 +84,10 @@ describe('Query', () => {
       }
     `;
     query(store, { query: INVALID_TODO_QUERY });
-    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledTimes(1);
     query(store, { query: INVALID_TODO_QUERY });
-    expect(console.error).toHaveBeenCalledTimes(1);
-    expect((console.error as any).mock.calls[0][0]).toMatch(/incomplete/);
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect((console.warn as any).mock.calls[0][0]).toMatch(/incomplete/);
   });
 
   it('should warn once for invalid sub-entities on an entity', () => {
@@ -103,9 +103,9 @@ describe('Query', () => {
       }
     `;
     query(store, { query: INVALID_TODO_QUERY });
-    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledTimes(1);
     query(store, { query: INVALID_TODO_QUERY });
-    expect(console.error).toHaveBeenCalledTimes(1);
-    expect((console.error as any).mock.calls[0][0]).toMatch(/writer/);
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect((console.warn as any).mock.calls[0][0]).toMatch(/writer/);
   });
 });

--- a/src/operations/query.ts
+++ b/src/operations/query.ts
@@ -1,5 +1,4 @@
-import warning from 'warning';
-
+import { warning } from '../helpers/warning';
 import {
   getFragments,
   getMainOperation,
@@ -330,10 +329,11 @@ const resolveResolverResult = (
 
   warning(
     false,
-    'Invalid resolver value: The resolver at `%s` returned a scalar (number, boolean, etc)' +
+    'Invalid resolver value: The resolver at `' +
+      key +
+      '` returned a scalar (number, boolean, etc)' +
       ', but the GraphQL query expects a selection set for this field.\n' +
-      'If necessary, use Cache.resolve() to resolve a link or entity from the cache.',
-    key
+      'If necessary, use Cache.resolve() to resolve a link or entity from the cache.'
   );
 
   return undefined;

--- a/src/operations/query.ts
+++ b/src/operations/query.ts
@@ -184,6 +184,10 @@ const readSelection = (
 
     if (isQuery) addDependency(fieldKey);
 
+    if (process.env.NODE_ENV !== 'production' && schemaPredicates) {
+      schemaPredicates.isFieldAvailableOnType(typename, fieldName);
+    }
+
     // We temporarily store the data field in here, but undefined
     // means that the value is missing from the cache
     let dataFieldValue: void | DataField;

--- a/src/operations/shared.ts
+++ b/src/operations/shared.ts
@@ -1,4 +1,4 @@
-import warning from 'warning';
+import { warning } from '../helpers/warning';
 import { FieldNode, InlineFragmentNode, FragmentDefinitionNode } from 'graphql';
 import { Fragments, Variables, SelectionSet, Scalar } from '../types';
 import { Store } from '../store';
@@ -34,13 +34,16 @@ const isFragmentHeuristicallyMatching = (
 
   warning(
     false,
-    'Heuristic Fragment Matching: A fragment is trying to match against the `%s` type, ' +
-      'but the type condition is `%s`. Since GraphQL allows for interfaces `%s` may be an' +
+    'Heuristic Fragment Matching: A fragment is trying to match against the `' +
+      typename +
+      '` type, ' +
+      'but the type condition is `' +
+      typeCondition +
+      '`. Since GraphQL allows for interfaces `' +
+      typeCondition +
+      '` may be an' +
       'interface.\nA schema needs to be defined for this match to be deterministic, ' +
-      'otherwise the fragment will be matched heuristically!',
-    typename,
-    typeCondition,
-    typeCondition
+      'otherwise the fragment will be matched heuristically!'
   );
 
   return !getSelectionSet(node).some(node => {

--- a/src/operations/write.test.ts
+++ b/src/operations/write.test.ts
@@ -45,7 +45,7 @@ describe('Query', () => {
         ],
       }
     );
-    spy.console = jest.spyOn(console, 'error');
+    spy.console = jest.spyOn(console, 'warn');
   });
 
   it('should warn once for invalid fields on an entity', () => {
@@ -71,7 +71,7 @@ describe('Query', () => {
         },
       }
     );
-    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledTimes(1);
     write(
       store,
       { query: INVALID_TODO_QUERY },
@@ -85,8 +85,8 @@ describe('Query', () => {
         },
       }
     );
-    expect(console.error).toHaveBeenCalledTimes(1);
-    expect((console.error as any).mock.calls[0][0]).toMatch(/incomplete/);
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect((console.warn as any).mock.calls[0][0]).toMatch(/incomplete/);
   });
 
   it('should warn once for invalid fields on an entity', () => {
@@ -117,7 +117,7 @@ describe('Query', () => {
       }
     );
     // Because of us indicating Todo:Writer as a scalar
-    expect(console.error).toHaveBeenCalledTimes(2);
+    expect(console.warn).toHaveBeenCalledTimes(2);
     write(
       store,
       { query: INVALID_TODO_QUERY },
@@ -134,7 +134,7 @@ describe('Query', () => {
       }
     );
 
-    expect(console.error).toHaveBeenCalledTimes(2);
-    expect((console.error as any).mock.calls[0][0]).toMatch(/writer/);
+    expect(console.warn).toHaveBeenCalledTimes(2);
+    expect((console.warn as any).mock.calls[0][0]).toMatch(/writer/);
   });
 });

--- a/src/operations/write.test.ts
+++ b/src/operations/write.test.ts
@@ -1,7 +1,6 @@
 import { Store } from '../store';
 import gql from 'graphql-tag';
 import { write } from './write';
-import { query } from './query';
 import { SchemaPredicates } from '../ast/schemaPredicates';
 
 const TODO_QUERY = gql`
@@ -49,51 +48,51 @@ describe('Query', () => {
     spy.console = jest.spyOn(console, 'error');
   });
 
-  it('test partial results', () => {
-    const result = query(store, { query: TODO_QUERY });
-    expect(result.partial).toBe(true);
-    expect(result.data).toEqual({
-      __typename: 'Query',
-      todos: [
-        {
-          id: '0',
-          text: 'Teach',
-          __typename: 'Todo',
-          author: null,
-          complete: null,
-        },
-        {
-          id: '1',
-          text: 'Learn',
-          __typename: 'Todo',
-          author: null,
-          complete: null,
-        },
-      ],
-    });
-  });
-
   it('should warn once for invalid fields on an entity', () => {
     const INVALID_TODO_QUERY = gql`
-      query {
-        todos {
+      mutation {
+        toggleTodo {
           id
           text
           incomplete
         }
       }
     `;
-    query(store, { query: INVALID_TODO_QUERY });
+    write(
+      store,
+      { query: INVALID_TODO_QUERY },
+      {
+        __typename: 'Mutation',
+        toggleTodo: {
+          __typename: 'Todo',
+          id: '0',
+          text: 'Teach',
+          incomplete: false,
+        },
+      }
+    );
     expect(console.error).toHaveBeenCalledTimes(1);
-    query(store, { query: INVALID_TODO_QUERY });
+    write(
+      store,
+      { query: INVALID_TODO_QUERY },
+      {
+        __typename: 'Mutation',
+        toggleTodo: {
+          __typename: 'Todo',
+          id: '0',
+          text: 'Teach',
+          incomplete: false,
+        },
+      }
+    );
     expect(console.error).toHaveBeenCalledTimes(1);
     expect((console.error as any).mock.calls[0][0]).toMatch(/incomplete/);
   });
 
-  it('should warn once for invalid sub-entities on an entity', () => {
+  it('should warn once for invalid fields on an entity', () => {
     const INVALID_TODO_QUERY = gql`
-      query {
-        todos {
+      mutation {
+        toggleTodo {
           id
           text
           writer {
@@ -102,10 +101,40 @@ describe('Query', () => {
         }
       }
     `;
-    query(store, { query: INVALID_TODO_QUERY });
-    expect(console.error).toHaveBeenCalledTimes(1);
-    query(store, { query: INVALID_TODO_QUERY });
-    expect(console.error).toHaveBeenCalledTimes(1);
+    write(
+      store,
+      { query: INVALID_TODO_QUERY },
+      {
+        __typename: 'Mutation',
+        toggleTodo: {
+          __typename: 'Todo',
+          id: '0',
+          text: 'Teach',
+          writer: {
+            id: '0',
+          },
+        },
+      }
+    );
+    // Because of us indicating Todo:Writer as a scalar
+    expect(console.error).toHaveBeenCalledTimes(2);
+    write(
+      store,
+      { query: INVALID_TODO_QUERY },
+      {
+        __typename: 'Mutation',
+        toggleTodo: {
+          __typename: 'Todo',
+          id: '0',
+          text: 'Teach',
+          writer: {
+            id: '0',
+          },
+        },
+      }
+    );
+
+    expect(console.error).toHaveBeenCalledTimes(2);
     expect((console.error as any).mock.calls[0][0]).toMatch(/writer/);
   });
 });

--- a/src/operations/write.ts
+++ b/src/operations/write.ts
@@ -1,4 +1,4 @@
-import warning from 'warning';
+import { warning } from '../helpers/warning';
 import { DocumentNode, FragmentDefinitionNode } from 'graphql';
 
 import {
@@ -45,9 +45,6 @@ interface Context {
   fragments: Fragments;
   schemaPredicates?: SchemaPredicates;
 }
-
-const scalarWarnings: { [fieldKey: string]: boolean } = {};
-const keyWarnings: { [fieldKey: string]: boolean } = {};
 
 /** Writes a request given its response to the store */
 export const write = (
@@ -166,8 +163,9 @@ export const writeFragment = (
     return warning(
       false,
       "Can't generate a key for writeFragment(...) data.\n" +
-        'You have to pass an `id` or `_id` field or create a custom `keys` config for `%s`.',
-      typeName
+        'You have to pass an `id` or `_id` field or create a custom `keys` config for `' +
+        typeName +
+        '`.'
     );
   }
 
@@ -221,13 +219,13 @@ const writeSelection = (
       store.removeRecord(fieldKey);
     } else {
       warning(
-        false || scalarWarnings[fieldKey],
-        'Invalid value: The field at `%s` is a scalar (number, boolean, etc)' +
+        false,
+        'Invalid value: The field at `' +
+          fieldKey +
+          '` is a scalar (number, boolean, etc)' +
           ', but the GraphQL query expects a selection set for this field.\n' +
-          'The value will still be cached, however this may lead to undefined behavior!',
-        fieldKey
+          'The value will still be cached, however this may lead to undefined behavior!'
       );
-      scalarWarnings[fieldKey] = true;
 
       // This is a rare case for invalid entities
       store.writeRecord(fieldValue, fieldKey);
@@ -267,18 +265,20 @@ const writeField = (
     entityKey !== null
   ) {
     warning(
-      false || keyWarnings[data.__typename],
-      'Invalid key: The GraphQL query at the field at `%s` has a selection set, ' +
+      false,
+      'Invalid key: The GraphQL query at the field at `' +
+        parentFieldKey +
+        '` has a selection set, ' +
         'but no key could be generated for the data at this field.\n' +
         'You have to request `id` or `_id` fields for all selection sets or create ' +
-        'a custom `keys` config for `%s`.\n' +
+        'a custom `keys` config for `' +
+        data.__typename +
+        '`.\n' +
         'Entities without keys will be embedded directly on the parent entity. ' +
-        'If this is intentional, create a `keys` config for `%s` that always returns null.',
-      parentFieldKey,
-      data.__typename,
-      data.__typename
+        'If this is intentional, create a `keys` config for `' +
+        data.__typename +
+        '` that always returns null.'
     );
-    keyWarnings[data.__typename] = true;
   }
 
   writeSelection(ctx, key, select, data);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5752,13 +5752,6 @@ walker@^1.0.7, walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
-warning@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
-  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
-  dependencies:
-    loose-envify "^1.0.0"
-
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"


### PR DESCRIPTION
adds selectionSet validation when we have a schema available…, this also introduces limiting an error will be identified and globally kept. This way we won't spam the user with errors of the same query happening twice/more