### PR TITLE
(fix) - dev-checks on query-write

### DIFF
--- a/src/operations/invalidate.ts
+++ b/src/operations/invalidate.ts
@@ -74,7 +74,11 @@ export const invalidateSelection = (
     const fieldArgs = getFieldArguments(node, variables);
     const fieldKey = joinKeys(entityKey, keyOfField(fieldName, fieldArgs));
 
-    if (process.env.NODE_ENV !== 'production' && ctx.schemaPredicates) {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      ctx.schemaPredicates &&
+      typename
+    ) {
       ctx.schemaPredicates.isFieldAvailableOnType(typename, fieldName);
     }
 

--- a/src/operations/query.test.ts
+++ b/src/operations/query.test.ts
@@ -108,4 +108,36 @@ describe('Query', () => {
     expect(console.warn).toHaveBeenCalledTimes(1);
     expect((console.warn as any).mock.calls[0][0]).toMatch(/writer/);
   });
+
+  // Issue#64
+  it('should not crash for valid queries', () => {
+    const VALID_QUERY = gql`
+      query getTodos {
+        todos {
+          id
+          text
+        }
+      }
+    `;
+    // Use new store to ensure bug reproduction
+    const store = new Store(new SchemaPredicates(schema));
+
+    let { data } = query(store, { query: VALID_QUERY });
+    expect(data).toEqual(null);
+
+    // @ts-ignore
+    write(
+      store,
+      { query: VALID_QUERY },
+      {
+        // Removing typename here would formerly crash this.
+        todos: [{ __typename: 'Todo', id: '0', text: 'Solve bug' }],
+      }
+    );
+    ({ data } = query(store, { query: VALID_QUERY }));
+    expect(data).toEqual({
+      __typename: 'Query',
+      todos: [{ __typename: 'Todo', id: '0', text: 'Solve bug' }],
+    });
+  });
 });

--- a/src/operations/query.test.ts
+++ b/src/operations/query.test.ts
@@ -125,10 +125,10 @@ describe('Query', () => {
     let { data } = query(store, { query: VALID_QUERY });
     expect(data).toEqual(null);
 
-    // @ts-ignore
     write(
       store,
       { query: VALID_QUERY },
+      // @ts-ignore
       {
         // Removing typename here would formerly crash this.
         todos: [{ __typename: 'Todo', id: '0', text: 'Solve bug' }],

--- a/src/operations/query.ts
+++ b/src/operations/query.ts
@@ -183,7 +183,7 @@ const readSelection = (
 
     if (isQuery) addDependency(fieldKey);
 
-    if (process.env.NODE_ENV !== 'production' && schemaPredicates) {
+    if (process.env.NODE_ENV !== 'production' && schemaPredicates && typename) {
       schemaPredicates.isFieldAvailableOnType(typename, fieldName);
     }
 

--- a/src/operations/write.ts
+++ b/src/operations/write.ts
@@ -204,7 +204,11 @@ const writeSelection = (
 
     if (isQuery) addDependency(fieldKey);
 
-    if (process.env.NODE_ENV !== 'production' && ctx.schemaPredicates) {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      ctx.schemaPredicates &&
+      typename
+    ) {
       ctx.schemaPredicates.isFieldAvailableOnType(typename, fieldName);
     }
 


### PR DESCRIPTION
resolves issue when we are initially writing from a server res…ponse. The top-level __typename won't be present that's why we have to add some guards to our dev-warnings for when this is not present

Fix #64 