### PR TITLE
Fix operation being referred to but undefined

### DIFF
--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -129,9 +129,11 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
     // Reexecute collected operations and delete them from the mapping
     pendingOperations.forEach(key => {
       if (key !== triggerOp.key) {
-        const op = ops.get(key) as Operation;
-        ops.delete(key);
-        client.reexecuteOperation(op);
+        const op = ops.get(key);
+        if (op !== undefined) {
+          ops.delete(key);
+          client.reexecuteOperation(op);
+        }
       }
     });
   };


### PR DESCRIPTION
Fix #69 

This PR shall be known as the **"Concurrency is Hard"-PR**

This is an interesting issue.
We thought it was impossible to be referring to the same
operation twice, since we're deduplicating for the operation
key when processing dependencies.
What we're not accounting for is that the operation may have
been reexecuted by another write to the cache.

This may happen in the following condition:

- A result comes back and a write operation is performed. Dependencies
  are stored as usual
- Another result comes back and triggers dependencies to be processed,
  which deletes some of the previous dependencies
- Meanwhile a potential third write starts which expects to see a
  deleted dependency, but it has already been reexecute by the second
  write operation.