### PR TITLE
Skip writing undefined fields and warn in dev

### DIFF
--- a/src/operations/write.test.ts
+++ b/src/operations/write.test.ts
@@ -137,4 +137,21 @@ describe('Query', () => {
     expect(console.warn).toHaveBeenCalledTimes(2);
     expect((console.warn as any).mock.calls[0][0]).toMatch(/writer/);
   });
+
+  it('should skip undefined values that are expected', () => {
+    const query = gql`
+      {
+        field
+      }
+    `;
+
+    write(store, { query }, { field: 'test' } as any);
+    // This should not overwrite the field
+    write(store, { query }, { field: undefined } as any);
+    // Because of us writing an undefined field
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect((console.warn as any).mock.calls[0][0]).toMatch(/undefined/);
+    // The field must still be `'test'`
+    expect(store.getRecord('Query.field')).toBe('test');
+  });
 });


### PR DESCRIPTION
We hit a case where an `undefined` value was written to the cache which lead to an incomplete query. This will most likely occur with invalid `updateQuery` calls or invalid optimistic results that include `undefined` fields, where the query expects a value.

We now skip writing these fields and instead warn about them. It should never be acceptable to write `undefined` to the cache, as we only want to write `null`. In rare cases `undefined` will indeed be written to remove records, but that's done with the explicit `store.removeRecord` call.

We're indeed seeing some warnings for this case in the `write.test.ts` tests, but I'm pretty sure those were expected before.