### PR TITLE
Normalise null args on fields by removing them

### DIFF
--- a/src/ast/variables.ts
+++ b/src/ast/variables.ts
@@ -17,12 +17,18 @@ export const getFieldArguments = (
   }
 
   const args = Object.create(null);
+  let argsSize = 0;
+
   for (let i = 0, l = node.arguments.length; i < l; i++) {
     const arg = node.arguments[i];
-    args[getName(arg)] = valueFromASTUntyped(arg.value, vars);
+    const value = valueFromASTUntyped(arg.value, vars);
+    if (value !== undefined && value !== null) {
+      args[getName(arg)] = value;
+      argsSize++;
+    }
   }
 
-  return args;
+  return argsSize > 0 ? args : null;
 };
 
 /** Returns a normalized form of variables with defaulted values */

--- a/src/test-utils/examples-1.test.ts
+++ b/src/test-utils/examples-1.test.ts
@@ -116,6 +116,40 @@ it('passes the "getting-started" example', () => {
   });
 });
 
+it('resolves missing, nullable arguments on fields', () => {
+  const store = new Store();
+
+  const GetWithVariables = gql`
+    query {
+      todo(first: null) {
+        __typename
+        id
+      }
+    }
+  `;
+
+  const GetWithoutVariables = gql`
+    query {
+      todo {
+        __typename
+        id
+      }
+    }
+  `;
+
+  const writeData = {
+    __typename: 'Query',
+    todo: {
+      __typename: 'Todo',
+      id: '123',
+    },
+  };
+
+  write(store, { query: GetWithVariables }, writeData);
+  const { data } = query(store, { query: GetWithoutVariables });
+  expect(data).toEqual(writeData);
+});
+
 it('respects property-level resolvers when given', () => {
   const store = new Store(undefined, {
     Todo: { text: () => 'hi' },


### PR DESCRIPTION
This means that `todo(x: null) {}` is assumed to be
the same as `todo {}`