### PR TITLE
Implement reading & traversing resolver results and pagination helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 /lib
-es
+/extras
 types
 coverage
 .vscode

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test": "jest",
     "coverage": "jest --coverage",
     "lint": "eslint . --ext .ts,.tsx",
-    "prepublishOnly": "run-s clean test build",
+    "prepare:extras": "./scripts/prepare-extras.js",
+    "prepublishOnly": "run-s clean test build prepare:extras",
     "codecov": "codecov"
   },
   "author": "Formidable",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -161,6 +161,29 @@ const config = {
 export default [
   {
     ...config,
+    input: './src/extras/index.ts',
+    plugins: makePlugins(false),
+    output: [
+      {
+        sourcemap: true,
+        legacy: true,
+        freeze: false,
+        esModule: false,
+        file: `./dist/${name}-extras.js`,
+        format: 'cjs'
+      },
+      {
+        sourcemap: true,
+        legacy: true,
+        freeze: false,
+        esModule: false,
+        file: `./dist/${name}-extras.es.js`,
+        format: 'esm'
+      }
+    ]
+  },
+  {
+    ...config,
     plugins: makePlugins(false),
     output: [
       {

--- a/scripts/prepare-extras.js
+++ b/scripts/prepare-extras.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const dir = path.resolve(__dirname, '../extras');
+if (!fs.existsSync(dir)) {
+  fs.mkdirSync(dir);
+}
+
+const pathToPkgJson = path.resolve(dir, 'package.json');
+if (fs.existsSync(pathToPkgJson)) {
+  fs.unlinkSync(pathToPkgJson);
+}
+
+const mainPkgJson = require('../package.json');
+
+const contents = JSON.stringify(
+  {
+    name: '@urql/exchange-graphcache-extras',
+    version: mainPkgJson.version,
+    private: true,
+    sideEffects: false,
+    description: mainPkgJson.description,
+    repository: mainPkgJson.repository,
+    bugs: mainPkgJson.bugs,
+    homepage: mainPkgJson.homepage,
+    main: '../dist/urql-exchange-graphcache-extras.js',
+    module: '../dist/urql-exchange-graphcache-extras.es.js',
+    types: '../dist/types/extras/index.d.ts',
+    source: '../src/extras/index.ts',
+    author: mainPkgJson.author,
+    license: mainPkgJson.license,
+  },
+  undefined,
+  2
+);
+
+fs.writeFileSync(pathToPkgJson, contents);

--- a/src/extras/index.ts
+++ b/src/extras/index.ts
@@ -1,0 +1,1 @@
+export { relayPagination } from './relayPagination';

--- a/src/extras/relayPagination.test.ts
+++ b/src/extras/relayPagination.test.ts
@@ -273,7 +273,7 @@ it('handles duplicate edges', () => {
   });
 });
 
-it('works with simultaneous forward and backward pagination', () => {
+it('works with simultaneous forward and backward pagination (outwards merging)', () => {
   const Pagination = gql`
     query($first: Int, $last: Int, $before: String, $after: String) {
       items(first: $first, last: $last, before: $before, after: $after) {
@@ -298,7 +298,7 @@ it('works with simultaneous forward and backward pagination', () => {
 
   const store = new Store(undefined, {
     Query: {
-      items: relayPagination(),
+      items: relayPagination({ mergeMode: 'outwards' }),
     },
   });
 
@@ -401,6 +401,146 @@ it('works with simultaneous forward and backward pagination', () => {
         pageThree.items.edges[0],
         pageOne.items.edges[0],
         pageTwo.items.edges[0],
+      ],
+      pageInfo: {
+        ...pageThree.items.pageInfo,
+        hasPreviousPage: true,
+        hasNextPage: true,
+        startCursor: '-1',
+        endCursor: '2',
+      },
+    },
+  });
+});
+
+it('works with simultaneous forward and backward pagination (inwards merging)', () => {
+  const Pagination = gql`
+    query($first: Int, $last: Int, $before: String, $after: String) {
+      items(first: $first, last: $last, before: $before, after: $after) {
+        __typename
+        edges {
+          __typename
+          node {
+            __typename
+            id
+          }
+        }
+        pageInfo {
+          __typename
+          hasPreviousPage
+          hasNextPage
+          startCursor
+          endCursor
+        }
+      }
+    }
+  `;
+
+  const store = new Store(undefined, {
+    Query: {
+      items: relayPagination({ mergeMode: 'inwards' }),
+    },
+  });
+
+  const pageOne = {
+    __typename: 'Query',
+    items: {
+      __typename: 'ItemsConnection',
+      edges: [
+        {
+          __typename: 'ItemEdge',
+          node: {
+            __typename: 'Item',
+            id: '1',
+          },
+        },
+      ],
+      pageInfo: {
+        __typename: 'PageInfo',
+        hasNextPage: true,
+        hasPreviousPage: false,
+        startCursor: null,
+        endCursor: '1',
+      },
+    },
+  };
+
+  const pageTwo = {
+    __typename: 'Query',
+    items: {
+      __typename: 'ItemsConnection',
+      edges: [
+        {
+          __typename: 'ItemEdge',
+          node: {
+            __typename: 'Item',
+            id: '2',
+          },
+        },
+      ],
+      pageInfo: {
+        __typename: 'PageInfo',
+        hasNextPage: true,
+        hasPreviousPage: true,
+        startCursor: '2',
+        endCursor: '2',
+      },
+    },
+  };
+
+  const pageThree = {
+    __typename: 'Query',
+    items: {
+      __typename: 'ItemsConnection',
+      edges: [
+        {
+          __typename: 'ItemEdge',
+          node: {
+            __typename: 'Item',
+            id: '-1',
+          },
+        },
+      ],
+      pageInfo: {
+        __typename: 'PageInfo',
+        hasNextPage: false,
+        hasPreviousPage: true,
+        startCursor: '-1',
+        endCursor: null,
+      },
+    },
+  };
+
+  write(
+    store,
+    { query: Pagination, variables: { after: '1', first: 1 } },
+    pageOne
+  );
+  write(
+    store,
+    { query: Pagination, variables: { after: '2', first: 1 } },
+    pageTwo
+  );
+  write(
+    store,
+    { query: Pagination, variables: { before: '1', last: 1 } },
+    pageThree
+  );
+
+  const res = query(store, {
+    query: Pagination,
+    variables: { before: '1', last: 1 },
+  });
+
+  expect(res.partial).toBe(false);
+  expect(res.data).toEqual({
+    ...pageThree,
+    items: {
+      ...pageThree.items,
+      edges: [
+        pageOne.items.edges[0],
+        pageTwo.items.edges[0],
+        pageThree.items.edges[0],
       ],
       pageInfo: {
         ...pageThree.items.pageInfo,

--- a/src/extras/relayPagination.test.ts
+++ b/src/extras/relayPagination.test.ts
@@ -287,7 +287,9 @@ it('works with simultaneous forward and backward pagination', () => {
         }
         pageInfo {
           __typename
+          hasPreviousPage
           hasNextPage
+          startCursor
           endCursor
         }
       }
@@ -355,7 +357,7 @@ it('works with simultaneous forward and backward pagination', () => {
           __typename: 'ItemEdge',
           node: {
             __typename: 'Item',
-            id: '3',
+            id: '-1',
           },
         },
       ],
@@ -363,8 +365,8 @@ it('works with simultaneous forward and backward pagination', () => {
         __typename: 'PageInfo',
         hasNextPage: false,
         hasPreviousPage: true,
+        startCursor: '-1',
         endCursor: null,
-        startCursor: '3',
       },
     },
   };
@@ -372,54 +374,41 @@ it('works with simultaneous forward and backward pagination', () => {
   write(
     store,
     { query: Pagination, variables: { after: '1', first: 1 } },
-    pageTwo
+    pageOne
   );
   write(
     store,
     { query: Pagination, variables: { after: '2', first: 1 } },
-    pageThree
+    pageTwo
   );
   write(
     store,
     { query: Pagination, variables: { before: '1', last: 1 } },
-    pageOne
+    pageThree
   );
 
-  const firstRes = query(store, {
+  const res = query(store, {
     query: Pagination,
     variables: { before: '1', last: 1 },
   });
-  const secondRes = query(store, {
-    query: Pagination,
-    variables: { first: 1, after: '1' },
-  });
-  const thirdRes = query(store, {
-    query: Pagination,
-    variables: { first: 1, after: '2' },
-  });
 
-  expect(firstRes.partial).toBe(false);
-  expect(secondRes.partial).toBe(false);
-  expect(thirdRes.partial).toBe(false);
-  expect(firstRes.data).toEqual({
-    ...pageOne,
-    items: {
-      ...pageOne.items,
-      edges: [pageOne.items.edges[0]],
-    },
-  });
-  expect(secondRes.data).toEqual({
-    ...pageTwo,
-    items: {
-      ...pageTwo.items,
-      edges: [pageTwo.items.edges[0]],
-    },
-  });
-  expect(thirdRes.data).toEqual({
+  expect(res.partial).toBe(false);
+  expect(res.data).toEqual({
     ...pageThree,
     items: {
       ...pageThree.items,
-      edges: [pageThree.items.edges[0]],
+      edges: [
+        pageThree.items.edges[0],
+        pageOne.items.edges[0],
+        pageTwo.items.edges[0],
+      ],
+      pageInfo: {
+        ...pageThree.items.pageInfo,
+        hasPreviousPage: true,
+        hasNextPage: true,
+        startCursor: '-1',
+        endCursor: '2',
+      },
     },
   });
 });

--- a/src/extras/relayPagination.test.ts
+++ b/src/extras/relayPagination.test.ts
@@ -101,7 +101,7 @@ it('works with backwards pagination', () => {
         }
         pageInfo {
           __typename
-          hasNextPage
+          hasPreviousPage
           startCursor
         }
       }
@@ -129,7 +129,7 @@ it('works with backwards pagination', () => {
       ],
       pageInfo: {
         __typename: 'PageInfo',
-        hasNextPage: true,
+        hasPreviousPage: true,
         startCursor: '2',
       },
     },
@@ -150,7 +150,7 @@ it('works with backwards pagination', () => {
       ],
       pageInfo: {
         __typename: 'PageInfo',
-        hasNextPage: false,
+        hasPreviousPage: false,
         startCursor: null,
       },
     },
@@ -167,78 +167,6 @@ it('works with backwards pagination', () => {
     items: {
       ...pageTwo.items,
       edges: [pageTwo.items.edges[0], pageOne.items.edges[0]],
-    },
-  });
-});
-
-it('falls back to cursor field instead of PageInfo cursors', () => {
-  const Pagination = gql`
-    query($cursor: String) {
-      items(first: 1, after: $cursor) {
-        __typename
-        edges {
-          __typename
-          cursor
-          node {
-            __typename
-            id
-          }
-        }
-      }
-    }
-  `;
-
-  const store = new Store(undefined, {
-    Query: {
-      items: relayPagination(),
-    },
-  });
-
-  const pageOne = {
-    __typename: 'Query',
-    items: {
-      __typename: 'ItemsConnection',
-      edges: [
-        {
-          __typename: 'ItemEdge',
-          cursor: '1',
-          node: {
-            __typename: 'Item',
-            id: '1',
-          },
-        },
-      ],
-    },
-  };
-
-  const pageTwo = {
-    __typename: 'Query',
-    items: {
-      __typename: 'ItemsConnection',
-      edges: [
-        {
-          __typename: 'ItemEdge',
-          cursor: '2',
-          node: {
-            __typename: 'Item',
-            id: '2',
-          },
-        },
-      ],
-    },
-  };
-
-  write(store, { query: Pagination, variables: { cursor: null } }, pageOne);
-  write(store, { query: Pagination, variables: { cursor: '1' } }, pageTwo);
-
-  const res = query(store, { query: Pagination });
-
-  expect(res.partial).toBe(false);
-  expect(res.data).toEqual({
-    ...pageTwo,
-    items: {
-      ...pageTwo.items,
-      edges: [pageOne.items.edges[0], pageTwo.items.edges[0]],
     },
   });
 });

--- a/src/extras/relayPagination.test.ts
+++ b/src/extras/relayPagination.test.ts
@@ -272,3 +272,154 @@ it('handles duplicate edges', () => {
     },
   });
 });
+
+it('works with simultaneous forward and backward pagination', () => {
+  const Pagination = gql`
+    query($first: Int, $last: Int, $before: String, $after: String) {
+      items(first: $first, last: $last, before: $before, after: $after) {
+        __typename
+        edges {
+          __typename
+          node {
+            __typename
+            id
+          }
+        }
+        pageInfo {
+          __typename
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  `;
+
+  const store = new Store(undefined, {
+    Query: {
+      items: relayPagination(),
+    },
+  });
+
+  const pageOne = {
+    __typename: 'Query',
+    items: {
+      __typename: 'ItemsConnection',
+      edges: [
+        {
+          __typename: 'ItemEdge',
+          node: {
+            __typename: 'Item',
+            id: '1',
+          },
+        },
+      ],
+      pageInfo: {
+        __typename: 'PageInfo',
+        hasNextPage: true,
+        hasPreviousPage: false,
+        startCursor: null,
+        endCursor: '1',
+      },
+    },
+  };
+
+  const pageTwo = {
+    __typename: 'Query',
+    items: {
+      __typename: 'ItemsConnection',
+      edges: [
+        {
+          __typename: 'ItemEdge',
+          node: {
+            __typename: 'Item',
+            id: '2',
+          },
+        },
+      ],
+      pageInfo: {
+        __typename: 'PageInfo',
+        hasNextPage: true,
+        hasPreviousPage: true,
+        startCursor: '2',
+        endCursor: '2',
+      },
+    },
+  };
+
+  const pageThree = {
+    __typename: 'Query',
+    items: {
+      __typename: 'ItemsConnection',
+      edges: [
+        {
+          __typename: 'ItemEdge',
+          node: {
+            __typename: 'Item',
+            id: '3',
+          },
+        },
+      ],
+      pageInfo: {
+        __typename: 'PageInfo',
+        hasNextPage: false,
+        hasPreviousPage: true,
+        endCursor: null,
+        startCursor: '3',
+      },
+    },
+  };
+
+  write(
+    store,
+    { query: Pagination, variables: { after: '1', first: 1 } },
+    pageTwo
+  );
+  write(
+    store,
+    { query: Pagination, variables: { after: '2', first: 1 } },
+    pageThree
+  );
+  write(
+    store,
+    { query: Pagination, variables: { before: '1', last: 1 } },
+    pageOne
+  );
+
+  const firstRes = query(store, {
+    query: Pagination,
+    variables: { before: '1', last: 1 },
+  });
+  const secondRes = query(store, {
+    query: Pagination,
+    variables: { first: 1, after: '1' },
+  });
+  const thirdRes = query(store, {
+    query: Pagination,
+    variables: { first: 1, after: '2' },
+  });
+
+  expect(firstRes.partial).toBe(false);
+  expect(secondRes.partial).toBe(false);
+  expect(thirdRes.partial).toBe(false);
+  expect(firstRes.data).toEqual({
+    ...pageOne,
+    items: {
+      ...pageOne.items,
+      edges: [pageOne.items.edges[0]],
+    },
+  });
+  expect(secondRes.data).toEqual({
+    ...pageTwo,
+    items: {
+      ...pageTwo.items,
+      edges: [pageTwo.items.edges[0]],
+    },
+  });
+  expect(thirdRes.data).toEqual({
+    ...pageThree,
+    items: {
+      ...pageThree.items,
+      edges: [pageThree.items.edges[0]],
+    },
+  });
+});

--- a/src/extras/relayPagination.test.ts
+++ b/src/extras/relayPagination.test.ts
@@ -1,0 +1,244 @@
+import gql from 'graphql-tag';
+import { query, write } from '../operations';
+import { Store } from '../store';
+import { relayPagination } from './relayPagination';
+
+it('works with forward pagination', () => {
+  const Pagination = gql`
+    query($cursor: String) {
+      items(first: 1, after: $cursor) {
+        __typename
+        edges {
+          __typename
+          node {
+            __typename
+            id
+          }
+        }
+        pageInfo {
+          __typename
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  `;
+
+  const store = new Store(undefined, {
+    Query: {
+      items: relayPagination(),
+    },
+  });
+
+  const pageOne = {
+    __typename: 'Query',
+    items: {
+      __typename: 'ItemsConnection',
+      edges: [
+        {
+          __typename: 'ItemEdge',
+          node: {
+            __typename: 'Item',
+            id: '1',
+          },
+        },
+      ],
+      pageInfo: {
+        __typename: 'PageInfo',
+        hasNextPage: true,
+        endCursor: '1',
+      },
+    },
+  };
+
+  const pageTwo = {
+    __typename: 'Query',
+    items: {
+      __typename: 'ItemsConnection',
+      edges: [
+        {
+          __typename: 'ItemEdge',
+          node: {
+            __typename: 'Item',
+            id: '2',
+          },
+        },
+      ],
+      pageInfo: {
+        __typename: 'PageInfo',
+        hasNextPage: false,
+        endCursor: null,
+      },
+    },
+  };
+
+  write(store, { query: Pagination, variables: { cursor: null } }, pageOne);
+  write(store, { query: Pagination, variables: { cursor: '1' } }, pageTwo);
+
+  const res = query(store, { query: Pagination });
+
+  expect(res.partial).toBe(false);
+  expect(res.data).toEqual({
+    ...pageTwo,
+    items: {
+      ...pageTwo.items,
+      edges: [pageOne.items.edges[0], pageTwo.items.edges[0]],
+    },
+  });
+});
+
+it('works with backwards pagination', () => {
+  const Pagination = gql`
+    query($cursor: String) {
+      items(last: 1, before: $cursor) {
+        __typename
+        edges {
+          __typename
+          node {
+            __typename
+            id
+          }
+        }
+        pageInfo {
+          __typename
+          hasNextPage
+          startCursor
+        }
+      }
+    }
+  `;
+
+  const store = new Store(undefined, {
+    Query: {
+      items: relayPagination(),
+    },
+  });
+
+  const pageOne = {
+    __typename: 'Query',
+    items: {
+      __typename: 'ItemsConnection',
+      edges: [
+        {
+          __typename: 'ItemEdge',
+          node: {
+            __typename: 'Item',
+            id: '2',
+          },
+        },
+      ],
+      pageInfo: {
+        __typename: 'PageInfo',
+        hasNextPage: true,
+        startCursor: '2',
+      },
+    },
+  };
+
+  const pageTwo = {
+    __typename: 'Query',
+    items: {
+      __typename: 'ItemsConnection',
+      edges: [
+        {
+          __typename: 'ItemEdge',
+          node: {
+            __typename: 'Item',
+            id: '1',
+          },
+        },
+      ],
+      pageInfo: {
+        __typename: 'PageInfo',
+        hasNextPage: false,
+        startCursor: null,
+      },
+    },
+  };
+
+  write(store, { query: Pagination, variables: { cursor: null } }, pageOne);
+  write(store, { query: Pagination, variables: { cursor: '2' } }, pageTwo);
+
+  const res = query(store, { query: Pagination });
+
+  expect(res.partial).toBe(false);
+  expect(res.data).toEqual({
+    ...pageTwo,
+    items: {
+      ...pageTwo.items,
+      edges: [pageTwo.items.edges[0], pageOne.items.edges[0]],
+    },
+  });
+});
+
+it('falls back to cursor field instead of PageInfo cursors', () => {
+  const Pagination = gql`
+    query($cursor: String) {
+      items(first: 1, after: $cursor) {
+        __typename
+        edges {
+          __typename
+          cursor
+          node {
+            __typename
+            id
+          }
+        }
+      }
+    }
+  `;
+
+  const store = new Store(undefined, {
+    Query: {
+      items: relayPagination(),
+    },
+  });
+
+  const pageOne = {
+    __typename: 'Query',
+    items: {
+      __typename: 'ItemsConnection',
+      edges: [
+        {
+          __typename: 'ItemEdge',
+          cursor: '1',
+          node: {
+            __typename: 'Item',
+            id: '1',
+          },
+        },
+      ],
+    },
+  };
+
+  const pageTwo = {
+    __typename: 'Query',
+    items: {
+      __typename: 'ItemsConnection',
+      edges: [
+        {
+          __typename: 'ItemEdge',
+          cursor: '2',
+          node: {
+            __typename: 'Item',
+            id: '2',
+          },
+        },
+      ],
+    },
+  };
+
+  write(store, { query: Pagination, variables: { cursor: null } }, pageOne);
+  write(store, { query: Pagination, variables: { cursor: '1' } }, pageTwo);
+
+  const res = query(store, { query: Pagination });
+
+  expect(res.partial).toBe(false);
+  expect(res.data).toEqual({
+    ...pageTwo,
+    items: {
+      ...pageTwo.items,
+      edges: [pageOne.items.edges[0], pageTwo.items.edges[0]],
+    },
+  });
+});

--- a/src/extras/relayPagination.test.ts
+++ b/src/extras/relayPagination.test.ts
@@ -170,3 +170,105 @@ it('works with backwards pagination', () => {
     },
   });
 });
+
+it('handles duplicate edges', () => {
+  const Pagination = gql`
+    query($cursor: String) {
+      items(first: 2, after: $cursor) {
+        __typename
+        edges {
+          __typename
+          node {
+            __typename
+            id
+          }
+        }
+        pageInfo {
+          __typename
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  `;
+
+  const store = new Store(undefined, {
+    Query: {
+      items: relayPagination(),
+    },
+  });
+
+  const pageOne = {
+    __typename: 'Query',
+    items: {
+      __typename: 'ItemsConnection',
+      edges: [
+        {
+          __typename: 'ItemEdge',
+          node: {
+            __typename: 'Item',
+            id: '1',
+          },
+        },
+        {
+          __typename: 'ItemEdge',
+          node: {
+            __typename: 'Item',
+            id: '2',
+          },
+        },
+      ],
+      pageInfo: {
+        __typename: 'PageInfo',
+        hasNextPage: true,
+        endCursor: '2',
+      },
+    },
+  };
+
+  const pageTwo = {
+    __typename: 'Query',
+    items: {
+      __typename: 'ItemsConnection',
+      edges: [
+        {
+          __typename: 'ItemEdge',
+          node: {
+            __typename: 'Item',
+            id: '2',
+          },
+        },
+        {
+          __typename: 'ItemEdge',
+          node: {
+            __typename: 'Item',
+            id: '3',
+          },
+        },
+      ],
+      pageInfo: {
+        __typename: 'PageInfo',
+        hasNextPage: false,
+        endCursor: null,
+      },
+    },
+  };
+
+  write(store, { query: Pagination, variables: { cursor: null } }, pageOne);
+  write(store, { query: Pagination, variables: { cursor: '1' } }, pageTwo);
+
+  const res = query(store, { query: Pagination });
+
+  expect(res.partial).toBe(false);
+  expect(res.data).toEqual({
+    ...pageTwo,
+    items: {
+      ...pageTwo.items,
+      edges: [
+        pageOne.items.edges[0],
+        pageTwo.items.edges[0],
+        pageTwo.items.edges[1],
+      ],
+    },
+  });
+});

--- a/src/extras/relayPagination.ts
+++ b/src/extras/relayPagination.ts
@@ -5,55 +5,67 @@ import { joinKeys, keyOfField } from '../helpers';
 interface PageInfo {
   endCursor: null | string;
   startCursor: null | string;
-  hasNextPage: null | boolean;
-  hasPreviousPage: null | boolean;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
 }
 
 interface Page {
-  __typename: string;
   edges: NullArray<string>;
   pageInfo: PageInfo;
 }
+
+const defaultPageInfo: PageInfo = {
+  endCursor: null,
+  startCursor: null,
+  hasNextPage: false,
+  hasPreviousPage: false,
+};
+
+const ensureKey = (x: any): string | null => (typeof x === 'string' ? x : null);
 
 const getPage = (cache: Store, linkKey: string): Page | null => {
   const link = cache.getLink(linkKey);
   if (!link || Array.isArray(link)) return null;
 
-  const typename = cache.resolve(link, '__typename');
-  const edges = cache.resolve(link, 'edges');
-
+  const edges = cache.resolve(link, 'edges') as NullArray<string>;
   if (
-    typeof typename !== 'string' ||
     !Array.isArray(edges) ||
     !edges.every(x => x === null || typeof x === 'string')
   ) {
     return null;
   }
 
-  const pageInfo = cache.resolve(link, 'pageInfo');
-  const page: Page = {
-    __typename: typename,
-    edges: edges as NullArray<string>,
-    pageInfo: {
-      endCursor: null,
-      startCursor: null,
-      hasNextPage: null,
-      hasPreviousPage: null,
-    },
-  };
+  const page: Page = { edges, pageInfo: defaultPageInfo };
+  const pageInfoKey = cache.resolve(link, 'pageInfo');
+  if (typeof pageInfoKey === 'string') {
+    const endCursor = ensureKey(cache.resolve(pageInfoKey, 'endCursor'));
+    const startCursor = ensureKey(cache.resolve(pageInfoKey, 'startCursor'));
+    const hasNextPage = cache.resolve(pageInfoKey, 'hasNextPage');
+    const hasPreviousPage = cache.resolve(pageInfoKey, 'hasPreviousPage');
 
-  if (typeof pageInfo === 'string') {
-    const endCursor = cache.resolve(pageInfo, 'endCursor');
-    const startCursor = cache.resolve(pageInfo, 'startCursor');
-    const hasNextPage = cache.resolve(pageInfo, 'hasNextPage');
-    const hasPreviousPage = cache.resolve(pageInfo, 'hasPreviousPage');
-    page.pageInfo.endCursor = typeof endCursor === 'string' ? endCursor : null;
-    page.pageInfo.startCursor =
-      typeof startCursor === 'string' ? startCursor : null;
-    page.pageInfo.hasNextPage =
-      typeof hasNextPage === 'boolean' ? hasNextPage : null;
-    page.pageInfo.hasPreviousPage =
-      typeof hasPreviousPage === 'boolean' ? hasPreviousPage : null;
+    const pageInfo: PageInfo = (page.pageInfo = {
+      hasNextPage: typeof hasNextPage === 'boolean' ? hasNextPage : !!endCursor,
+      hasPreviousPage:
+        typeof hasPreviousPage === 'boolean' ? hasPreviousPage : !!startCursor,
+      endCursor,
+      startCursor,
+    });
+
+    if (pageInfo.endCursor === null) {
+      const edge = edges[edges.length - 1];
+      if (edge) {
+        const endCursor = cache.resolve(edge, 'cursor');
+        pageInfo.endCursor = ensureKey(endCursor);
+      }
+    }
+
+    if (pageInfo.startCursor === null) {
+      const edge = edges[0];
+      if (edge) {
+        const startCursor = cache.resolve(edge, 'cursor');
+        pageInfo.startCursor = ensureKey(startCursor);
+      }
+    }
   }
 
   return page;
@@ -62,18 +74,63 @@ const getPage = (cache: Store, linkKey: string): Page | null => {
 export const relayPagination = (): Resolver => {
   return (_parent, args, cache, info) => {
     const { parentKey: key, fieldName } = info;
+    const fieldKey = joinKeys(key, keyOfField(fieldName, args));
     const connections = cache.resolveConnections(key, fieldName);
-    if (connections.length === 0) return undefined;
-    let connection;
-    const fieldKey = joinKeys(info.parentKey, keyOfField(info.fieldName, args));
+    const size = connections.length;
 
-    // Use find so we can short-circuit early if needed.
-    connections.find(con => {
-      if (fieldKey === con[1]) return (connection = con[1]);
-    });
+    let hasCachedConnection = false;
+    for (let i = 0; i < size; i++) {
+      if (connections[i][1] === fieldKey) {
+        hasCachedConnection = true;
+        break;
+      }
+    }
 
-    if (!connection) return undefined;
-    const page = getPage(cache, connection);
-    return page ? (page as any) : undefined;
+    const entityKey = cache.resolveValueOrLink(fieldKey);
+    if (!hasCachedConnection || typeof entityKey !== 'string') {
+      return undefined;
+    }
+
+    const typename = cache.resolve(entityKey, '__typename');
+
+    const pageInfoKey = ensureKey(cache.resolve(entityKey, 'pageInfo'));
+    const pageInfoTypename = cache.resolve(pageInfoKey, '__typename');
+    if (typeof typename !== 'string' || typeof pageInfoTypename !== 'string') {
+      return undefined;
+    }
+
+    let edges: NullArray<string> = [];
+    let pageInfo: PageInfo = { ...defaultPageInfo };
+
+    for (let i = 0; i < size; i++) {
+      const [args, linkKey] = connections[i];
+      const page = getPage(cache, linkKey);
+      if (page === null) {
+        continue;
+      } else if (args.after) {
+        edges = edges.concat(page.edges);
+        pageInfo.endCursor = page.pageInfo.endCursor;
+        pageInfo.hasNextPage = page.pageInfo.hasNextPage;
+      } else if (args.before) {
+        edges = page.edges.concat(edges);
+        pageInfo.startCursor = page.pageInfo.startCursor;
+        pageInfo.hasPreviousPage = page.pageInfo.hasPreviousPage;
+      } else if (!args.before && !args.after) {
+        edges = edges.concat(page.edges);
+        pageInfo = page.pageInfo;
+      }
+    }
+
+    return {
+      __typename: typename,
+      edges,
+      pageInfo: {
+        __typename: pageInfoTypename,
+        endCursor: pageInfo.endCursor,
+        startCursor: pageInfo.startCursor,
+        hasNextPage: pageInfo.hasNextPage,
+        hasPreviousPage: pageInfo.hasPreviousPage,
+      },
+    };
   };
 };

--- a/src/extras/relayPagination.ts
+++ b/src/extras/relayPagination.ts
@@ -1,6 +1,5 @@
 import { Store } from '../store';
 import { Resolver, NullArray } from '../types';
-import { joinKeys, keyOfField } from '../helpers';
 
 export type MergeMode = 'outwards' | 'inwards';
 
@@ -107,20 +106,11 @@ export const relayPagination = (params: PaginationParams = {}): Resolver => {
 
   return (_parent, args, cache, info) => {
     const { parentKey: key, fieldName } = info;
-    const fieldKey = joinKeys(key, keyOfField(fieldName, args));
+
     const connections = cache.resolveConnections(key, fieldName);
     const size = connections.length;
-
-    let hasCachedConnection = false;
-    for (let i = 0; i < size; i++) {
-      if (connections[i][1] === fieldKey) {
-        hasCachedConnection = true;
-        break;
-      }
-    }
-
-    const entityKey = cache.resolveValueOrLink(fieldKey);
-    if (!hasCachedConnection || typeof entityKey !== 'string') {
+    const entityKey = ensureKey(cache.resolve(key, fieldName, args));
+    if (size === 0 || !entityKey) {
       return undefined;
     }
 

--- a/src/extras/relayPagination.ts
+++ b/src/extras/relayPagination.ts
@@ -1,0 +1,111 @@
+import invariant from 'invariant';
+import { Resolver, NullArray, Data, Variables } from '../types';
+
+interface ConnectionArgs {
+  first?: number;
+  last?: number;
+  before?: string;
+  after?: string;
+}
+
+interface Edge {
+  cursor?: string;
+  node?: Data | null;
+}
+
+interface PageInfo {
+  hasNextPage?: boolean;
+  startCursor?: string;
+  endCursor?: string;
+}
+
+interface ConnectionData {
+  edges: NullArray<Edge>;
+  pageInfo?: PageInfo;
+}
+
+export const relayPagination = (): Resolver => {
+  return (_, args, cache, info) => {
+    const { first, last } = args as ConnectionArgs;
+
+    invariant(
+      typeof first !== 'number' || typeof last !== 'number',
+      'relayPagination(...) was used with both a `first` and `last` argument,\n' +
+        'but it must not be used with both at the same time.'
+    );
+
+    invariant(
+      typeof first === 'number' || typeof last === 'number',
+      'relayPagination(...) was used without a `first` and `last` argument,\n' +
+        'but it must not be used with at least one of them.'
+    );
+
+    const isForwardPagination = typeof first === 'number';
+    const size = (isForwardPagination ? first : last) || 0;
+
+    invariant(
+      size > 0,
+      'relayPagination(...) was used with a `first` or `last` argument that is less than zero.'
+    );
+
+    const childArgs: Variables = {};
+    if (typeof first === 'number') childArgs.first = first;
+    if (typeof last === 'number') childArgs.last = last;
+
+    const mergedEdges: NullArray<Edge> = [];
+
+    let data = cache.resolve(
+      info.parentKey,
+      info.fieldName,
+      childArgs
+    ) as ConnectionData;
+    while (data && Array.isArray(data.edges)) {
+      const { edges, pageInfo } = data;
+
+      // Add the receives nodes to the list of nodes
+      if (isForwardPagination) {
+        for (let i = 0; i < size; i++) mergedEdges.push(edges[i]);
+      } else {
+        for (let i = size - 1; i >= 0; i--) mergedEdges.unshift(edges[i]);
+      }
+
+      // Stop traversing pages when no next page is expected
+      if (pageInfo && pageInfo.hasNextPage === false) break;
+
+      // Retrive the cursor from PageInfo
+      let nextCursor =
+        pageInfo &&
+        (isForwardPagination ? pageInfo.endCursor : pageInfo.startCursor);
+
+      // If no cursor is on PageInfo then fall back to edges.cursor
+      const edge = isForwardPagination ? mergedEdges[size - 1] : mergedEdges[0];
+      if (!nextCursor && edge && edge.cursor) {
+        nextCursor = edge.cursor;
+      }
+
+      invariant(
+        typeof nextCursor !== 'string',
+        'relayPagination(...) tried to receive the next cursor for the pagination, but ' +
+          'neither the `pageInfo.' +
+          (isForwardPagination ? 'endCursor' : 'startCursor') +
+          '` nor the `edges.cursor` fields were valid cursors.'
+      );
+
+      // Update the cursor on the child arguments
+      if (isForwardPagination) {
+        childArgs.after = nextCursor || null;
+      } else {
+        childArgs.before = nextCursor || null;
+      }
+
+      // Retrive the next page of data
+      data = cache.resolve(
+        info.parentKey,
+        info.fieldName,
+        childArgs
+      ) as ConnectionData;
+    }
+
+    return { ...data, edges: mergedEdges } as ConnectionData;
+  };
+};

--- a/src/extras/relayPagination.ts
+++ b/src/extras/relayPagination.ts
@@ -1,112 +1,71 @@
-import { warning } from '../helpers/warning';
-import { Resolver, NullArray, Variables } from '../types';
+import { Store } from '../store';
+import { Resolver, NullArray } from '../types';
 
-interface ConnectionArgs {
-  first?: number;
-  last?: number;
-  before?: string;
-  after?: string;
+interface PageInfo {
+  endCursor: null | string;
+  startCursor: null | string;
+  hasNextPage: null | boolean;
+  hasPreviousPage: null | boolean;
 }
 
+interface Page {
+  __typename: string;
+  edges: NullArray<string>;
+  pageInfo: PageInfo;
+}
+
+const getPage = (cache: Store, linkKey: string): Page | null => {
+  const link = cache.getLink(linkKey);
+  if (!link || Array.isArray(link)) return null;
+
+  const typename = cache.resolve(link, '__typename');
+  const edges = cache.resolve(link, 'edges');
+
+  if (
+    typeof typename !== 'string' ||
+    !Array.isArray(edges) ||
+    !edges.every(x => x === null || typeof x === 'string')
+  ) {
+    return null;
+  }
+
+  const pageInfo = cache.resolve(link, 'pageInfo');
+  const page: Page = {
+    __typename: typename,
+    edges: edges as NullArray<string>,
+    pageInfo: {
+      endCursor: null,
+      startCursor: null,
+      hasNextPage: null,
+      hasPreviousPage: null,
+    },
+  };
+
+  if (typeof pageInfo === 'string') {
+    const endCursor = cache.resolve(pageInfo, 'endCursor');
+    const startCursor = cache.resolve(pageInfo, 'startCursor');
+    const hasNextPage = cache.resolve(pageInfo, 'hasNextPage');
+    const hasPreviousPage = cache.resolve(pageInfo, 'hasPreviousPage');
+    page.pageInfo.endCursor = typeof endCursor === 'string' ? endCursor : null;
+    page.pageInfo.startCursor =
+      typeof startCursor === 'string' ? startCursor : null;
+    page.pageInfo.hasNextPage =
+      typeof hasNextPage === 'boolean' ? hasNextPage : null;
+    page.pageInfo.hasPreviousPage =
+      typeof hasPreviousPage === 'boolean' ? hasPreviousPage : null;
+  }
+
+  return page;
+};
+
 export const relayPagination = (): Resolver => {
-  return (_, args, cache, info) => {
+  return (_parent, _args, cache, info) => {
     const { parentKey: key, fieldName } = info;
-    const { first, last } = args as ConnectionArgs;
+    const connections = cache.resolveConnections(key, fieldName);
+    if (connections.length === 0) return undefined;
 
-    if (typeof first === 'number' && typeof last === 'number') {
-      warning(
-        false,
-        'relayPagination(...) was used with both a `first` and `last` argument,\n' +
-          'but it must not be used with both at the same time.'
-      );
-
-      return null;
-    } else if (typeof first !== 'number' && typeof last !== 'number') {
-      warning(
-        false,
-        'relayPagination(...) was used without a `first` and `last` argument,\n' +
-          'but it must not be used with at least one of them.'
-      );
-
-      return null;
-    }
-
-    const isForwardPagination = typeof first === 'number';
-    const size = (isForwardPagination ? first : last) || 0;
-
-    if (size <= 0) {
-      warning(
-        false,
-        'relayPagination(...) was used with a `first` or `last` argument that is less than zero.'
-      );
-    }
-
-    const childArgs: Variables = {};
-    if (typeof first === 'number') childArgs.first = first;
-    if (typeof last === 'number') childArgs.last = last;
-
-    const mergedEdges: NullArray<string> = [];
-
-    let dataKey = cache.resolve(key, fieldName, childArgs) as string;
-    let edgesKeys = cache.resolve(dataKey, 'edges') as string;
-    let infoKey = cache.resolve(dataKey, 'pageInfo') as string;
-    let prevInfoKey: string | null = null;
-
-    const connectionType = cache.resolve(dataKey, '__typename');
-    if (!connectionType) {
-      return undefined;
-    }
-
-    while (dataKey !== null && Array.isArray(edgesKeys)) {
-      // Store the last valid info key
-      prevInfoKey = infoKey;
-
-      // Add the receives nodes to the list of nodes
-      if (isForwardPagination) {
-        for (let i = 0; i < size; i++) mergedEdges.push(edgesKeys[i]);
-      } else {
-        for (let i = size - 1; i >= 0; i--) mergedEdges.unshift(edgesKeys[i]);
-      }
-
-      // Stop traversing pages when no next page is expected
-      const hasMore = cache.resolve(
-        infoKey,
-        isForwardPagination ? 'hasNextPage' : 'hasPreviousPage'
-      );
-      if (hasMore === false || edgesKeys.length === 0) break;
-
-      // Retrive the cursor from PageInfo
-      let nextCursor = infoKey
-        ? cache.resolve(
-            infoKey,
-            isForwardPagination ? 'endCursor' : 'startCursor'
-          )
-        : null;
-
-      // If no cursor is on PageInfo then fall back to edges.cursor
-      if (!nextCursor) {
-        const edge = isForwardPagination ? edgesKeys[size - 1] : edgesKeys[0];
-        nextCursor = edge ? cache.resolve(edge, 'cursor') : null;
-        if (!nextCursor) break;
-      }
-
-      // Update the cursor on the child arguments
-      if (isForwardPagination) {
-        childArgs.after = nextCursor || null;
-      } else {
-        childArgs.before = nextCursor || null;
-      }
-
-      // Retrive the next page of data
-      dataKey = cache.resolve(key, fieldName, childArgs) as string;
-      edgesKeys = cache.resolve(dataKey, 'edges') as string;
-      infoKey = cache.resolve(dataKey, 'pageInfo') as string;
-    }
-
-    return {
-      __typename: connectionType,
-      edges: mergedEdges,
-      pageInfo: prevInfoKey || undefined,
-    } as any;
+    // TODO
+    const page = getPage(cache, connections[0][1]);
+    return page ? (page as any) : undefined;
   };
 };

--- a/src/extras/relayPagination.ts
+++ b/src/extras/relayPagination.ts
@@ -69,8 +69,11 @@ export const relayPagination = (): Resolver => {
       }
 
       // Stop traversing pages when no next page is expected
-      const hasNextPage = cache.resolve(infoKey, 'hasNextPage');
-      if (hasNextPage === false || edgesKeys.length === 0) break;
+      const hasMore = cache.resolve(
+        infoKey,
+        isForwardPagination ? 'hasNextPage' : 'hasPreviousPage'
+      );
+      if (hasMore === false || edgesKeys.length === 0) break;
 
       // Retrive the cursor from PageInfo
       let nextCursor = infoKey

--- a/src/extras/relayPagination.ts
+++ b/src/extras/relayPagination.ts
@@ -10,7 +10,6 @@ interface ConnectionArgs {
 
 export const relayPagination = (): Resolver => {
   return (_, args, cache, info) => {
-    // TODO: Add bailout if cursor was passed
     const { parentKey: key, fieldName } = info;
     const { first, last } = args as ConnectionArgs;
 

--- a/src/extras/relayPagination.ts
+++ b/src/extras/relayPagination.ts
@@ -1,5 +1,4 @@
-import { Store } from '../store';
-import { Resolver, NullArray } from '../types';
+import { Cache, Resolver, NullArray } from '../types';
 
 export type MergeMode = 'outwards' | 'inwards';
 
@@ -29,7 +28,7 @@ const defaultPageInfo: PageInfo = {
 const ensureKey = (x: any): string | null => (typeof x === 'string' ? x : null);
 
 const concatEdges = (
-  cache: Store,
+  cache: Cache,
   leftEdges: NullArray<string>,
   rightEdges: NullArray<string>
 ) => {
@@ -53,9 +52,9 @@ const concatEdges = (
   return newEdges;
 };
 
-const getPage = (cache: Store, linkKey: string): Page | null => {
-  const link = cache.getLink(linkKey);
-  if (!link || Array.isArray(link)) return null;
+const getPage = (cache: Cache, linkKey: string): Page | null => {
+  const link = ensureKey(cache.resolveValueOrLink(linkKey));
+  if (!link) return null;
 
   const edges = cache.resolve(link, 'edges') as NullArray<string>;
   if (

--- a/src/extras/relayPagination.ts
+++ b/src/extras/relayPagination.ts
@@ -1,4 +1,4 @@
-import invariant from 'invariant';
+import { warning } from '../helpers/warning';
 import { Resolver, NullArray, Variables } from '../types';
 
 interface ConnectionArgs {
@@ -14,25 +14,33 @@ export const relayPagination = (): Resolver => {
     const { parentKey: key, fieldName } = info;
     const { first, last } = args as ConnectionArgs;
 
-    invariant(
-      typeof first !== 'number' || typeof last !== 'number',
-      'relayPagination(...) was used with both a `first` and `last` argument,\n' +
-        'but it must not be used with both at the same time.'
-    );
+    if (typeof first === 'number' && typeof last === 'number') {
+      warning(
+        false,
+        'relayPagination(...) was used with both a `first` and `last` argument,\n' +
+          'but it must not be used with both at the same time.'
+      );
 
-    invariant(
-      typeof first === 'number' || typeof last === 'number',
-      'relayPagination(...) was used without a `first` and `last` argument,\n' +
-        'but it must not be used with at least one of them.'
-    );
+      return null;
+    } else if (typeof first !== 'number' && typeof last !== 'number') {
+      warning(
+        false,
+        'relayPagination(...) was used without a `first` and `last` argument,\n' +
+          'but it must not be used with at least one of them.'
+      );
+
+      return null;
+    }
 
     const isForwardPagination = typeof first === 'number';
     const size = (isForwardPagination ? first : last) || 0;
 
-    invariant(
-      size > 0,
-      'relayPagination(...) was used with a `first` or `last` argument that is less than zero.'
-    );
+    if (size <= 0) {
+      warning(
+        false,
+        'relayPagination(...) was used with a `first` or `last` argument that is less than zero.'
+      );
+    }
 
     const childArgs: Variables = {};
     if (typeof first === 'number') childArgs.first = first;

--- a/src/operations/query.ts
+++ b/src/operations/query.ts
@@ -44,6 +44,7 @@ export interface QueryResult {
 interface Context {
   parentTypeName: string;
   parentKey: string;
+  parentFieldKey: string;
   fieldName: string;
   partial: boolean;
   store: Store;
@@ -75,6 +76,7 @@ export const read = (
   const ctx: Context = {
     parentTypeName: rootKey,
     parentKey: rootKey,
+    parentFieldKey: '',
     fieldName: '',
     variables: normalizeVariables(operation, request.variables),
     fragments: getFragments(request.query),
@@ -203,6 +205,7 @@ export const readFragment = (
   const ctx: Context = {
     parentTypeName: typename,
     parentKey: entityKey,
+    parentFieldKey: '',
     fieldName: '',
     variables: variables || {},
     fragments,
@@ -262,6 +265,7 @@ const readSelection = (
       // that the resolver will receive
       ctx.parentTypeName = typename;
       ctx.parentKey = entityKey;
+      ctx.parentFieldKey = fieldKey;
       ctx.fieldName = fieldName;
 
       // We have a resolver for this field.

--- a/src/operations/query.ts
+++ b/src/operations/query.ts
@@ -355,6 +355,8 @@ const readResolverResult = (
 ): Data | undefined => {
   const { store, variables, schemaPredicates } = ctx;
   const entityKey = store.keyOfEntity(result) || key;
+  addDependency(entityKey);
+
   const resolvedTypename = result.__typename;
   const typename = store.getField(entityKey, '__typename') || resolvedTypename;
 

--- a/src/operations/query.ts
+++ b/src/operations/query.ts
@@ -42,6 +42,9 @@ export interface QueryResult {
 }
 
 interface Context {
+  parentTypeName: string;
+  parentKey: string;
+  fieldName: string;
   partial: boolean;
   store: Store;
   variables: Variables;
@@ -70,6 +73,9 @@ export const read = (
   const rootSelect = getSelectionSet(operation);
 
   const ctx: Context = {
+    parentTypeName: rootKey,
+    parentKey: rootKey,
+    fieldName: '',
     variables: normalizeVariables(operation, request.variables),
     fragments: getFragments(request.query),
     partial: false,
@@ -195,6 +201,9 @@ export const readFragment = (
   }
 
   const ctx: Context = {
+    parentTypeName: typename,
+    parentKey: entityKey,
+    fieldName: '',
     variables: variables || {},
     fragments,
     partial: false,
@@ -249,6 +258,12 @@ const readSelection = (
 
     const resolvers = store.resolvers[typename];
     if (resolvers !== undefined && typeof resolvers[fieldName] === 'function') {
+      // We have to update the information in context to reflect the info
+      // that the resolver will receive
+      ctx.parentTypeName = typename;
+      ctx.parentKey = entityKey;
+      ctx.fieldName = fieldName;
+
       // We have a resolver for this field.
       // Prepare the actual fieldValue, so that the resolver can use it
       if (fieldValue !== undefined) {

--- a/src/operations/write.ts
+++ b/src/operations/write.ts
@@ -42,6 +42,7 @@ export interface WriteResult {
 interface Context {
   parentTypeName: string;
   parentKey: string;
+  parentFieldKey: string;
   fieldName: string;
   result: WriteResult;
   store: Store;
@@ -77,6 +78,7 @@ export const startWrite = (
   const ctx: Context = {
     parentTypeName: operationName,
     parentKey: operationName,
+    parentFieldKey: '',
     fieldName: '',
     variables: normalizeVariables(operation, request.variables),
     fragments: getFragments(request.query),
@@ -115,6 +117,7 @@ export const writeOptimistic = (
   const ctx: Context = {
     parentTypeName: mutationRootKey,
     parentKey: mutationRootKey,
+    parentFieldKey: '',
     fieldName: '',
     variables: normalizeVariables(operation, request.variables),
     fragments: getFragments(request.query),
@@ -192,6 +195,7 @@ export const writeFragment = (
   const ctx: Context = {
     parentTypeName: typename,
     parentKey: entityKey,
+    parentFieldKey: '',
     fieldName: '',
     variables: variables || {},
     fragments,
@@ -366,9 +370,11 @@ const writeRoot = (
     }
 
     if (isRootField) {
+      const fieldKey = joinKeys(typename, keyOfField(fieldName, fieldArgs));
       // We have to update the context to reflect up-to-date ResolveInfo
       ctx.parentTypeName = typename;
       ctx.parentKey = typename;
+      ctx.parentFieldKey = fieldKey;
       ctx.fieldName = fieldName;
 
       // We run side-effect updates after the default, normalized updates

--- a/src/operations/write.ts
+++ b/src/operations/write.ts
@@ -312,7 +312,9 @@ const writeField = (
     const typename = data.__typename;
 
     warning(
-      typename.endsWith('Connection') || typename.endsWith('Edge'),
+      typename.endsWith('Connection') ||
+        typename.endsWith('Edge') ||
+        typename === 'PageInfo',
       'Invalid key: The GraphQL query at the field at `' +
         parentFieldKey +
         '` has a selection set, ' +

--- a/src/operations/write.ts
+++ b/src/operations/write.ts
@@ -260,8 +260,10 @@ const writeSelection = (
     } else if (!isScalar(fieldValue)) {
       // Process the field and write links for the child entities that have been written
       const fieldSelect = getSelectionSet(node);
+      const connectionKey = joinKeys(entityKey, fieldName);
       const link = writeField(ctx, fieldKey, fieldSelect, fieldValue);
       store.writeLink(link, fieldKey);
+      store.writeConnection(connectionKey, fieldKey, fieldArgs);
       store.removeRecord(fieldKey);
     } else {
       warning(

--- a/src/operations/write.ts
+++ b/src/operations/write.ts
@@ -40,11 +40,14 @@ export interface WriteResult {
 }
 
 interface Context {
+  parentTypeName: string;
+  parentKey: string;
+  fieldName: string;
   result: WriteResult;
   store: Store;
   variables: Variables;
   fragments: Fragments;
-  isOptimistic?: boolean;
+  optimistic?: boolean;
   schemaPredicates?: SchemaPredicates;
 }
 
@@ -68,16 +71,19 @@ export const startWrite = (
   const operation = getMainOperation(request.query);
   const result: WriteResult = { dependencies: getCurrentDependencies() };
 
+  const select = getSelectionSet(operation);
+  const operationName = store.getRootKey(operation.operation);
+
   const ctx: Context = {
+    parentTypeName: operationName,
+    parentKey: operationName,
+    fieldName: '',
     variables: normalizeVariables(operation, request.variables),
     fragments: getFragments(request.query),
     result,
     store,
     schemaPredicates: store.schemaPredicates,
   };
-
-  const select = getSelectionSet(operation);
-  const operationName = ctx.store.getRootKey(operation.operation);
 
   if (operationName === ctx.store.getRootKey('query')) {
     writeSelection(ctx, operationName, select, data);
@@ -98,22 +104,25 @@ export const writeOptimistic = (
   const operation = getMainOperation(request.query);
   const result: WriteResult = { dependencies: getCurrentDependencies() };
 
-  const ctx: Context = {
-    variables: normalizeVariables(operation, request.variables),
-    fragments: getFragments(request.query),
-    result,
-    store,
-    schemaPredicates: store.schemaPredicates,
-    isOptimistic: true,
-  };
-
-  const mutationRootKey = ctx.store.getRootKey('mutation');
-  const operationName = ctx.store.getRootKey(operation.operation);
+  const mutationRootKey = store.getRootKey('mutation');
+  const operationName = store.getRootKey(operation.operation);
   invariant(
     operationName === mutationRootKey,
     'writeOptimistic(...) was called with an operation that is not a mutation.\n' +
       'This case is unsupported and should never occur.'
   );
+
+  const ctx: Context = {
+    parentTypeName: mutationRootKey,
+    parentKey: mutationRootKey,
+    fieldName: '',
+    variables: normalizeVariables(operation, request.variables),
+    fragments: getFragments(request.query),
+    result,
+    store,
+    schemaPredicates: store.schemaPredicates,
+    optimistic: true,
+  };
 
   const select = getSelectionSet(operation);
   const data = Object.create(null);
@@ -125,6 +134,9 @@ export const writeOptimistic = (
       const fieldName = getName(node);
       const resolver = ctx.store.optimisticMutations[fieldName];
       if (resolver !== undefined) {
+        // We have to update the context to reflect up-to-date ResolveInfo
+        ctx.fieldName = fieldName;
+
         const fieldArgs = getFieldArguments(node, ctx.variables);
         const fieldSelect = getSelectionSet(node);
         const resolverValue = resolver(fieldArgs || {}, ctx.store, ctx);
@@ -178,6 +190,9 @@ export const writeFragment = (
   }
 
   const ctx: Context = {
+    parentTypeName: typename,
+    parentKey: entityKey,
+    fieldName: '',
     variables: variables || {},
     fragments,
     result: { dependencies: getCurrentDependencies() },
@@ -214,7 +229,7 @@ const writeSelection = (
 
     if (process.env.NODE_ENV !== 'production') {
       if (fieldValue === undefined) {
-        const advice = ctx.isOptimistic
+        const advice = ctx.optimistic
           ? '\nYour optimistic result may be missing a field!'
           : '';
 
@@ -347,6 +362,11 @@ const writeRoot = (
     }
 
     if (isRootField) {
+      // We have to update the context to reflect up-to-date ResolveInfo
+      ctx.parentTypeName = typename;
+      ctx.parentKey = typename;
+      ctx.fieldName = fieldName;
+
       // We run side-effect updates after the default, normalized updates
       // so that the data is already available in-store if necessary
       const updater = ctx.store.updates[typename][fieldName];

--- a/src/store.ts
+++ b/src/store.ts
@@ -234,8 +234,14 @@ export class Store {
     return link ? link : null;
   }
 
-  resolve(entity: Data | string, field: string, args?: Variables): DataField {
-    if (typeof entity === 'string') {
+  resolve(
+    entity: Data | string | null,
+    field: string,
+    args?: Variables
+  ): DataField {
+    if (entity === null) {
+      return null;
+    } else if (typeof entity === 'string') {
       addDependency(entity);
       return this.resolveValueOrLink(joinKeys(entity, keyOfField(field, args)));
     } else {

--- a/src/store.ts
+++ b/src/store.ts
@@ -270,7 +270,6 @@ export class Store {
       addDependency(entity);
       return this.resolveValueOrLink(joinKeys(entity, keyOfField(field, args)));
     } else {
-      // This gives us __typename:key
       const entityKey = this.keyOfEntity(entity);
       if (entityKey === null) return null;
       addDependency(entityKey);
@@ -278,6 +277,27 @@ export class Store {
         joinKeys(entityKey, keyOfField(field, args))
       );
     }
+  }
+
+  resolveConnections(
+    entity: Data | string | null,
+    field: string
+  ): Connection[] {
+    let connections: undefined | Connection[];
+    if (typeof entity === 'string') {
+      connections = Pessimism.get(this.connections, joinKeys(entity, field));
+    } else if (entity !== null) {
+      const entityKey = this.keyOfEntity(entity);
+      if (entityKey !== null) {
+        addDependency(entityKey);
+        connections = Pessimism.get(
+          this.connections,
+          joinKeys(entityKey, field)
+        );
+      }
+    }
+
+    return connections !== undefined ? connections : [];
   }
 
   invalidateQuery(dataQuery: DocumentNode, variables: Variables) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -6,6 +6,7 @@ import * as Pessimism from 'pessimism';
 import {
   EntityField,
   Link,
+  Connection,
   ResolverConfig,
   DataField,
   Variables,
@@ -81,6 +82,7 @@ interface QueryInput {
 
 export class Store {
   records: Pessimism.Map<EntityField>;
+  connections: Pessimism.Map<Connection[]>;
   links: Pessimism.Map<Link>;
 
   resolvers: ResolverConfig;
@@ -100,7 +102,9 @@ export class Store {
     keys?: KeyingConfig
   ) {
     this.records = Pessimism.asMutable(Pessimism.make());
+    this.connections = Pessimism.asMutable(Pessimism.make());
     this.links = Pessimism.asMutable(Pessimism.make());
+
     this.resolvers = resolvers || {};
     this.optimisticMutations = optimisticMutations || {};
     this.keys = keys || {};
@@ -177,6 +181,10 @@ export class Store {
 
   clearOptimistic(optimisticKey: number) {
     this.records = Pessimism.clearOptimistic(this.records, optimisticKey);
+    this.connections = Pessimism.clearOptimistic(
+      this.connections,
+      optimisticKey
+    );
     this.links = Pessimism.clearOptimistic(this.links, optimisticKey);
   }
 
@@ -221,6 +229,23 @@ export class Store {
 
   writeLink(link: Link, key: string) {
     return (this.links = mapSet(this.links, key, link));
+  }
+
+  writeConnection(key: string, linkKey: string, args: Variables | null) {
+    if (args === null) return this.connections;
+
+    let connections = Pessimism.get(this.connections, key);
+    const connection: Connection = [args, linkKey];
+    if (connections === undefined) {
+      connections = [connection];
+    } else {
+      for (let i = 0, l = connections.length; i < l; i++)
+        if (connections[i][1] === linkKey) return this.connections;
+      connections = connections.slice();
+      connections.push(connection);
+    }
+
+    return (this.connections = mapSet(this.connections, key, connections));
   }
 
   resolveValueOrLink(fieldKey: string): DataField {

--- a/src/test-utils/examples-2.test.ts
+++ b/src/test-utils/examples-2.test.ts
@@ -8,6 +8,7 @@ const Item = gql`
       __typename
       id
       complete
+      text
     }
   }
 `;
@@ -22,6 +23,7 @@ const Pagination = gql`
           __typename
           id
           complete
+          text
         }
       }
       pageInfo {
@@ -44,7 +46,8 @@ it('allows custom resolvers to resolve nested, unkeyed data', () => {
             node: {
               __typename: 'Todo',
               id: '1',
-              // This won't be the actual result:
+              // The `complete` field will be overwritten here, but we're
+              // leaving out the `text` field
               complete: true,
             },
           },
@@ -67,6 +70,7 @@ it('allows custom resolvers to resolve nested, unkeyed data', () => {
         __typename: 'Todo',
         id: '1',
         complete: false,
+        text: 'Example',
       },
     }
   );
@@ -85,8 +89,8 @@ it('allows custom resolvers to resolve nested, unkeyed data', () => {
           node: {
             __typename: 'Todo',
             id: '1',
-            // This is still false (see previous write):
-            complete: false,
+            complete: true, // This is now true and not false!
+            text: 'Example', // This is still present
           },
         },
       ],
@@ -129,6 +133,7 @@ it('allows custom resolvers to resolve nested, unkeyed data with embedded links'
         __typename: 'Todo',
         id: '1',
         complete: false,
+        text: 'Example',
       },
     }
   );
@@ -148,6 +153,7 @@ it('allows custom resolvers to resolve nested, unkeyed data with embedded links'
             __typename: 'Todo',
             id: '1',
             complete: false,
+            text: 'Example',
           },
         },
       ],

--- a/src/test-utils/examples-2.test.ts
+++ b/src/test-utils/examples-2.test.ts
@@ -216,6 +216,7 @@ it('allows custom resolvers to resolve mixed data (keyable and unkeyable)', () =
 
   const res = query(store, { query: ItemDetailed });
   expect(res.partial).toBe(false);
+  expect(Array.from(res.dependencies).includes('Author:x')).toBe(true);
   expect(res.data).toEqual({
     __typename: 'Query',
     todo: {

--- a/src/test-utils/examples-2.test.ts
+++ b/src/test-utils/examples-2.test.ts
@@ -13,6 +13,22 @@ const Item = gql`
   }
 `;
 
+const ItemDetailed = gql`
+  {
+    todo {
+      __typename
+      id
+      details {
+        __typename
+        authors {
+          __typename
+          id
+        }
+      }
+    }
+  }
+`;
+
 const Pagination = gql`
   query {
     todos {
@@ -139,9 +155,7 @@ it('allows custom resolvers to resolve nested, unkeyed data with embedded links'
   );
 
   const res = query(store, { query: Pagination });
-
   expect(res.partial).toBe(false);
-
   expect(res.data).toEqual({
     __typename: 'Query',
     todos: {
@@ -161,6 +175,60 @@ it('allows custom resolvers to resolve nested, unkeyed data with embedded links'
         __typename: 'PageInfo',
         hasNextPage: true,
         endCursor: '1',
+      },
+    },
+  });
+});
+
+it('allows custom resolvers to resolve mixed data (keyable and unkeyable)', () => {
+  const store = new Store(undefined, {
+    Query: {
+      todo: () => ({
+        __typename: 'Todo',
+        id: '1',
+        details: {
+          __typename: 'TodoDetails',
+        },
+      }),
+    },
+  });
+
+  write(
+    store,
+    { query: ItemDetailed },
+    {
+      __typename: 'Query',
+      todo: {
+        __typename: 'Todo',
+        id: '1',
+        details: {
+          __typename: 'TodoDetails',
+          authors: [
+            {
+              __typename: 'Author',
+              id: 'x',
+            },
+          ],
+        },
+      },
+    }
+  );
+
+  const res = query(store, { query: ItemDetailed });
+  expect(res.partial).toBe(false);
+  expect(res.data).toEqual({
+    __typename: 'Query',
+    todo: {
+      __typename: 'Todo',
+      id: '1',
+      details: {
+        __typename: 'TodoDetails',
+        authors: [
+          {
+            __typename: 'Author',
+            id: 'x',
+          },
+        ],
       },
     },
   });

--- a/src/test-utils/examples-2.test.ts
+++ b/src/test-utils/examples-2.test.ts
@@ -1,0 +1,161 @@
+import gql from 'graphql-tag';
+import { query, write } from '../operations';
+import { Store } from '../store';
+
+const Item = gql`
+  {
+    todo {
+      __typename
+      id
+      complete
+    }
+  }
+`;
+
+const Pagination = gql`
+  query {
+    todos {
+      __typename
+      edges {
+        __typename
+        node {
+          __typename
+          id
+          complete
+        }
+      }
+      pageInfo {
+        __typename
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`;
+
+it('allows custom resolvers to resolve nested, unkeyed data', () => {
+  const store = new Store(undefined, {
+    Query: {
+      todos: () => ({
+        __typename: 'TodosConnection',
+        edges: [
+          {
+            __typename: 'TodoEdge',
+            node: {
+              __typename: 'Todo',
+              id: '1',
+              // This won't be the actual result:
+              complete: true,
+            },
+          },
+        ],
+        pageInfo: {
+          __typename: 'PageInfo',
+          hasNextPage: true,
+          endCursor: '1',
+        },
+      }),
+    },
+  });
+
+  write(
+    store,
+    { query: Item },
+    {
+      __typename: 'Query',
+      todo: {
+        __typename: 'Todo',
+        id: '1',
+        complete: false,
+      },
+    }
+  );
+
+  const res = query(store, { query: Pagination });
+
+  expect(res.partial).toBe(false);
+
+  expect(res.data).toEqual({
+    __typename: 'Query',
+    todos: {
+      __typename: 'TodosConnection',
+      edges: [
+        {
+          __typename: 'TodoEdge',
+          node: {
+            __typename: 'Todo',
+            id: '1',
+            // This is still false (see previous write):
+            complete: false,
+          },
+        },
+      ],
+      pageInfo: {
+        __typename: 'PageInfo',
+        hasNextPage: true,
+        endCursor: '1',
+      },
+    },
+  });
+});
+
+it('allows custom resolvers to resolve nested, unkeyed data with embedded links', () => {
+  const store = new Store(undefined, {
+    Query: {
+      todos: (_, __, cache) => ({
+        __typename: 'TodosConnection',
+        edges: [
+          {
+            __typename: 'TodoEdge',
+            // This is a key instead of the full entity:
+            node: cache.keyOfEntity({ __typename: 'Todo', id: '1' }),
+          },
+        ],
+        pageInfo: {
+          __typename: 'PageInfo',
+          hasNextPage: true,
+          endCursor: '1',
+        },
+      }),
+    },
+  });
+
+  write(
+    store,
+    { query: Item },
+    {
+      __typename: 'Query',
+      todo: {
+        __typename: 'Todo',
+        id: '1',
+        complete: false,
+      },
+    }
+  );
+
+  const res = query(store, { query: Pagination });
+
+  expect(res.partial).toBe(false);
+
+  expect(res.data).toEqual({
+    __typename: 'Query',
+    todos: {
+      __typename: 'TodosConnection',
+      edges: [
+        {
+          __typename: 'TodoEdge',
+          node: {
+            __typename: 'Todo',
+            id: '1',
+            complete: false,
+          },
+        },
+      ],
+      pageInfo: {
+        __typename: 'PageInfo',
+        hasNextPage: true,
+        endCursor: '1',
+      },
+    },
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,7 +63,7 @@ export type Resolver = (
   args: Variables,
   cache: Store,
   info: ResolveInfo
-) => DataField;
+) => DataField | undefined;
 
 export interface ResolverConfig {
   [typeName: string]: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,13 +33,14 @@ export interface DataFields {
   [fieldName: string]: DataField;
 }
 
-export type Data = SystemFields & DataFields;
-export type Link<Key = string> = null | Key | NullArray<Key>;
-export type ResolvedLink = Link<Data>;
-
 export interface Variables {
   [name: string]: Scalar | Scalar[] | Variables | NullArray<Variables>;
 }
+
+export type Data = SystemFields & DataFields;
+export type Link<Key = string> = null | Key | NullArray<Key>;
+export type ResolvedLink = Link<Data>;
+export type Connection = [Variables, string];
 
 // This is an input operation
 export interface OperationRequest {

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,8 +48,13 @@ export interface OperationRequest {
 }
 
 export interface ResolveInfo {
+  parentTypeName: string;
+  parentKey: string;
+  fieldName: string;
   fragments: Fragments;
   variables: Variables;
+  partial?: boolean;
+  optimistic?: boolean;
 }
 
 // Cache resolvers are user-defined to overwrite an entity field result

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 import { DocumentNode, FragmentDefinitionNode, SelectionNode } from 'graphql';
-import { Store } from './store';
 
 // Helper types
 export type NullArray<T> = Array<null | T>;
@@ -59,11 +58,63 @@ export interface ResolveInfo {
   optimistic?: boolean;
 }
 
+export interface QueryInput {
+  query: string | DocumentNode;
+  variables?: Variables;
+}
+
+export interface Cache {
+  /** keyOfEntity() returns the key for an entity or null if it's unkeyable */
+  keyOfEntity(data: Data): string | null;
+
+  /** resolve() retrieves the value (or link) of a field on any entity, given a partial/keyable entity or an entity key */
+  resolve(
+    entity: Data | string | null,
+    fieldName: string,
+    args?: Variables
+  ): DataField;
+
+  /** resolveValueOrLink() returns a field's value on an entity, given that field's key */
+  resolveValueOrLink(fieldKey: string): DataField;
+
+  /** resolveConnections() retrieves all known connections (arguments and links) for a given field on an entity */
+  resolveConnections(
+    entity: Data | string | null,
+    fieldName: string
+  ): Connection[];
+
+  /** invalidateQuery() invalidates all data of a given query */
+  invalidateQuery(query: DocumentNode, variables?: Variables): void;
+
+  /** updateQuery() can be used to update the data of a given query using an updater function */
+  updateQuery(
+    input: QueryInput,
+    updater: (data: Data | null) => Data | null
+  ): void;
+
+  /** readQuery() retrieves the data for a given query */
+  readQuery(input: QueryInput): Data | null;
+
+  /** readFragment() retrieves the data for a given fragment, given a partial/keyable entity or an entity key */
+  readFragment(
+    fragment: DocumentNode,
+    entity: string | Data,
+    variables?: Variables
+  ): Data | null;
+
+  /** writeFragment() can be used to update the data of a given fragment, given an entity that is supposed to be written using the fragment */
+  writeFragment(
+    fragment: DocumentNode,
+    data: Data,
+    variables?: Variables
+  ): void;
+}
+
 // Cache resolvers are user-defined to overwrite an entity field result
 export type Resolver = (
   parent: Data,
   args: Variables,
-  cache: Store,
+  cache: Cache,
   info: ResolveInfo
 ) => DataField | undefined;
 
@@ -76,7 +127,7 @@ export interface ResolverConfig {
 export type UpdateResolver = (
   result: Data,
   args: Variables,
-  cache: Store,
+  cache: Cache,
   info: ResolveInfo
 ) => void;
 
@@ -93,7 +144,7 @@ export interface UpdatesConfig {
 
 export type OptimisticMutationResolver = (
   vars: Variables,
-  cache: Store,
+  cache: Cache,
   info: ResolveInfo
 ) => null | Data | NullArray<Data>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,7 @@ export interface OperationRequest {
 export interface ResolveInfo {
   parentTypeName: string;
   parentKey: string;
+  parentFieldKey: string;
   fieldName: string;
   fragments: Fragments;
   variables: Variables;


### PR DESCRIPTION
The extras folder could be put into a separate bundle at `/extras`. Eventually this should contain helpers to implement automatic pagination.

Right now there’s an (untested) Relay pagination helper that automatically does forward and backwards pagination merging.

I had to reimplement how we treat cache resolvers. Before the user could either return scalars from it (no selection set), or keys / keyable entities (for selection sets) which would be then retrieved from the cache. This is essentially our equivalent of Apollo’s cache redirects.

There’s a third option now, for unkeyed results the user can return nested results that eventually are resolved as they were before. But unkeyed entities will be read from the resolver result directly

Edit: And a fourth option, keyed entities won't fall back to `readSelection`, but instead will read values from the cache when they're missing from the resolver result, until. This only returns to `readSelection` when a link field is `undefined`.

The minzipped size will go from `4.91kB` to `5.22kB`