### PR TITLE
(refactor) - trim size

### DIFF
--- a/src/ast/schemaPredicates.ts
+++ b/src/ast/schemaPredicates.ts
@@ -48,9 +48,10 @@ export class SchemaPredicates {
     const objectType = this.schema.getType(typename);
     expectObjectType(objectType, typename);
 
-    const abstractNode = abstractType as GraphQLAbstractType;
-    const concreteNode = objectType as GraphQLObjectType;
-    return this.schema.isPossibleType(abstractNode, concreteNode);
+    return this.schema.isPossibleType(
+      abstractType as GraphQLAbstractType,
+      objectType as GraphQLObjectType
+    );
   }
 }
 

--- a/src/ast/traversal.ts
+++ b/src/ast/traversal.ts
@@ -13,11 +13,8 @@ import {
 import { getName } from './node';
 import { Fragments, Variables } from '../types';
 
-const isFragmentNode = (
-  node: DefinitionNode
-): node is FragmentDefinitionNode => {
-  return node.kind === Kind.FRAGMENT_DEFINITION;
-};
+const isFragmentNode = (node: DefinitionNode): node is FragmentDefinitionNode =>
+  node.kind === Kind.FRAGMENT_DEFINITION;
 
 /** Returns the main operation's definition */
 export const getMainOperation = (
@@ -47,12 +44,12 @@ export const shouldInclude = (
   node: SelectionNode,
   vars: Variables
 ): boolean => {
-  if (node.directives === undefined) {
+  const { directives } = node;
+  if (directives === undefined) {
     return true;
   }
 
   // Finds any @include or @skip directive that forces the node to be skipped
-  const { directives } = node;
   for (let i = 0, l = directives.length; i < l; i++) {
     const directive = directives[i];
     const name = getName(directive);

--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -163,7 +163,7 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
       if (!ops.has(op.key)) {
         ops.set(
           op.key,
-          op.context.requestPolicy === 'network-only'
+          getRequestPolicy(op) === 'network-only'
             ? toRequestPolicy(op, 'cache-and-network')
             : op
         );

--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -60,14 +60,12 @@ const isMutationOperation = (op: Operation): boolean =>
 
 // Returns whether an operation can potentially be read from cache
 const isCacheableQuery = (op: Operation): boolean => {
-  const policy = getRequestPolicy(op);
-  return isQueryOperation(op) && policy !== 'network-only';
+  return isQueryOperation(op) && getRequestPolicy(op) !== 'network-only';
 };
 
 // Returns whether an operation potentially triggers an optimistic update
 const isOptimisticMutation = (op: Operation): boolean => {
-  const policy = getRequestPolicy(op);
-  return isMutationOperation(op) && policy !== 'network-only';
+  return isMutationOperation(op) && getRequestPolicy(op) !== 'network-only';
 };
 
 // Copy an operation and change the requestPolicy to skip the cache

--- a/src/operations/invalidate.ts
+++ b/src/operations/invalidate.ts
@@ -50,7 +50,7 @@ export const invalidateSelection = (
   entityKey: string,
   select: SelectionSet
 ) => {
-  const { store, variables } = ctx;
+  const { store } = ctx;
   const isQuery = entityKey === 'Query';
 
   let typename;
@@ -71,8 +71,10 @@ export const invalidateSelection = (
   let node;
   while ((node = iter.next()) !== undefined) {
     const fieldName = getName(node);
-    const fieldArgs = getFieldArguments(node, variables);
-    const fieldKey = joinKeys(entityKey, keyOfField(fieldName, fieldArgs));
+    const fieldKey = joinKeys(
+      entityKey,
+      keyOfField(fieldName, getFieldArguments(node, ctx.variables))
+    );
 
     if (
       process.env.NODE_ENV !== 'production' &&

--- a/src/operations/shared.ts
+++ b/src/operations/shared.ts
@@ -48,9 +48,10 @@ const isFragmentHeuristicallyMatching = (
 
   return !getSelectionSet(node).some(node => {
     if (!isFieldNode(node)) return false;
-    const fieldName = getName(node);
-    const fieldArgs = getFieldArguments(node, ctx.variables);
-    const fieldKey = keyOfField(fieldName, fieldArgs);
+    const fieldKey = keyOfField(
+      getName(node),
+      getFieldArguments(node, ctx.variables)
+    );
     return !ctx.store.hasField(joinKeys(entityKey, fieldKey));
   });
 };

--- a/src/store.ts
+++ b/src/store.ts
@@ -169,8 +169,6 @@ export class Store implements Cache {
       key = `${id}`;
     } else if (_id !== undefined && _id !== null) {
       key = `${_id}`;
-    } else {
-      return null;
     }
 
     return key ? `${typename}:${key}` : null;
@@ -202,8 +200,7 @@ export class Store implements Cache {
     fieldName: string,
     args?: Variables
   ): EntityField {
-    const fieldKey = joinKeys(entityKey, keyOfField(fieldName, args));
-    return this.getRecord(fieldKey);
+    return this.getRecord(joinKeys(entityKey, keyOfField(fieldName, args)));
   }
 
   writeField(
@@ -212,8 +209,11 @@ export class Store implements Cache {
     fieldName: string,
     args?: Variables
   ) {
-    const fieldKey = joinKeys(entityKey, keyOfField(fieldName, args));
-    return (this.records = mapSet(this.records, fieldKey, field));
+    return (this.records = mapSet(
+      this.records,
+      joinKeys(entityKey, keyOfField(fieldName, args)),
+      field
+    ));
   }
 
   getLink(key: string): undefined | Link {


### PR DESCRIPTION
I have explored our codebase while freshing up on the operations and noticed a lot of low-hanging fruit. I've resolved these while traversing the codebase, resulting in -90bytes! This optimises for gzip

There are also a few cases where we will have less minor gc runs since we are not storing the result and sometimes where we store the result later after a few potential bailouts.