### PR TITLE
Add traversal stack to all errors and warnings

### DIFF
--- a/scripts/transform-invariant-warning.js
+++ b/scripts/transform-invariant-warning.js
@@ -16,7 +16,7 @@ const plugin = ({ template, types: t }) => {
     visitor: {
       CallExpression(path) {
         const { name } = path.node.callee;
-        if ((name === 'warning') && !path.node[visited]) {
+        if ((name === 'warn') && !path.node[visited]) {
           path.node[visited] = true;
           path.replaceWith(wrapWithDevCheck({ NODE: path.node }));
         } else if (name === 'invariant' && !path.node[visited]) {

--- a/src/ast/schemaPredicates.ts
+++ b/src/ast/schemaPredicates.ts
@@ -10,7 +10,7 @@ import {
   GraphQLUnionType,
 } from 'graphql';
 
-import { invariant, warning } from '../helpers/help';
+import { invariant, warn } from '../helpers/help';
 
 export class SchemaPredicates {
   schema: GraphQLSchema;
@@ -65,8 +65,7 @@ const getField = (
 
   const field = object.getFields()[fieldName];
   if (field === undefined) {
-    warning(
-      false,
+    warn(
       'Invalid field: The field `' +
         fieldName +
         '` does not exist on `' +

--- a/src/helpers/help.ts
+++ b/src/helpers/help.ts
@@ -3,15 +3,48 @@
 // Every warning and error comes with a number that uniquely identifies them.
 // You can read more about the messages themselves in `docs/help.md`
 
+import { Kind, ExecutableDefinitionNode, InlineFragmentNode } from 'graphql';
+import { Ref } from '../types';
+
+type DebugNode = ExecutableDefinitionNode | InlineFragmentNode;
+
 const helpUrl =
   '\nhttps://github.com/FormidableLabs/urql-exchange-graphcache/blob/master/docs/help.md#';
 const cache = new Set<string>();
 
+export const currentDebugStack: Ref<string[]> = { current: [] };
+
+export const pushDebugNode = (typename: void | string, node: DebugNode) => {
+  let identifier = '';
+  if (node.kind === Kind.INLINE_FRAGMENT) {
+    identifier = typename
+      ? `Inline Fragment on "${typename}"`
+      : 'Inline Fragment';
+  } else if (node.kind === Kind.OPERATION_DEFINITION) {
+    const name = node.name ? `"${node.name.value}"` : 'Unnamed';
+    identifier = `${name} ${node.operation}`;
+  } else if (node.kind === Kind.FRAGMENT_DEFINITION) {
+    identifier = `"${node.name.value}" Fragment`;
+  }
+
+  if (identifier) {
+    currentDebugStack.current.push(identifier);
+  }
+};
+
+const getDebugOutput = (): string =>
+  currentDebugStack.current.length
+    ? '\n(Caused At: ' + currentDebugStack.current.join(', ') + ')'
+    : '';
+
 export const invariant = (clause: any, message: string, code: number) => {
   if (!clause) {
-    const error = new Error(
-      (message || 'Minfied Error #' + code + '\n') + helpUrl + code
-    );
+    let errorMessage = message || 'Minfied Error #' + code + '\n';
+    if (process.env.NODE_ENV !== 'production') {
+      errorMessage += getDebugOutput();
+    }
+
+    const error = new Error(errorMessage + helpUrl + code);
     error.name = 'Graphcache Error';
     throw error;
   }
@@ -19,7 +52,7 @@ export const invariant = (clause: any, message: string, code: number) => {
 
 export const warn = (message: string, code: number) => {
   if (!cache.has(message)) {
-    console.warn(message + helpUrl + code);
+    console.warn(message + getDebugOutput() + helpUrl + code);
     cache.add(message);
   }
 };

--- a/src/helpers/help.ts
+++ b/src/helpers/help.ts
@@ -17,8 +17,8 @@ export const invariant = (clause: any, message: string, code: number) => {
   }
 };
 
-export const warning = (clause: any, message: string, code: number) => {
-  if (!clause && !cache.has(message)) {
+export const warn = (message: string, code: number) => {
+  if (!cache.has(message)) {
     console.warn(message + helpUrl + code);
     cache.add(message);
   }

--- a/src/operations/query.ts
+++ b/src/operations/query.ts
@@ -28,7 +28,7 @@ import {
   clearStoreState,
 } from '../store';
 
-import { warn } from '../helpers/help';
+import { warn, pushDebugNode } from '../helpers/help';
 import { SelectionIterator, isScalar } from './shared';
 import { joinKeys, keyOfField } from '../helpers';
 import { SchemaPredicates } from '../ast/schemaPredicates';
@@ -83,6 +83,10 @@ export const read = (
     store,
     schemaPredicates: store.schemaPredicates,
   };
+
+  if (process.env.NODE_ENV !== 'production') {
+    pushDebugNode(rootKey, operation);
+  }
 
   let data = input || Object.create(null);
   data =
@@ -201,6 +205,10 @@ export const readFragment = (
     );
 
     return null;
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    pushDebugNode(typename, fragment);
   }
 
   const ctx: Context = {

--- a/src/operations/query.ts
+++ b/src/operations/query.ts
@@ -28,7 +28,7 @@ import {
   clearStoreState,
 } from '../store';
 
-import { warning } from '../helpers/help';
+import { warn } from '../helpers/help';
 import { SelectionIterator, isScalar } from './shared';
 import { joinKeys, keyOfField } from '../helpers';
 import { SchemaPredicates } from '../ast/schemaPredicates';
@@ -172,8 +172,7 @@ export const readFragment = (
   const names = Object.keys(fragments);
   const fragment = fragments[names[0]] as FragmentDefinitionNode;
   if (fragment === undefined) {
-    warning(
-      false,
+    warn(
       'readFragment(...) was called with an empty fragment.\n' +
         'You have to call it with at least one fragment in your GraphQL document.',
       6
@@ -193,8 +192,7 @@ export const readFragment = (
       : entity;
 
   if (!entityKey) {
-    warning(
-      false,
+    warn(
       "Can't generate a key for readFragment(...).\n" +
         'You have to pass an `id` or `_id` field or create a custom `keys` config for `' +
         typename +
@@ -377,8 +375,7 @@ const readResolverResult = (
     (resolvedTypename && typename !== resolvedTypename)
   ) {
     // TODO: This may be an invalid error for resolvers that return interfaces
-    warning(
-      false,
+    warn(
       'Invalid resolver data: The resolver at `' +
         entityKey +
         '` returned an ' +
@@ -522,8 +519,7 @@ const resolveResolverResult = (
       ? readSelection(ctx, result, select, data)
       : readResolverResult(ctx, key, select, data, result);
   } else {
-    warning(
-      false,
+    warn(
       'Invalid resolver value: The field at `' +
         key +
         '` is a scalar (number, boolean, etc)' +

--- a/src/operations/shared.ts
+++ b/src/operations/shared.ts
@@ -2,7 +2,8 @@ import { FieldNode, InlineFragmentNode, FragmentDefinitionNode } from 'graphql';
 import { Fragments, Variables, SelectionSet, Scalar } from '../types';
 import { Store } from '../store';
 import { joinKeys, keyOfField } from '../helpers';
-import { warn } from '../helpers/help';
+import { warn, pushDebugNode } from '../helpers/help';
+import { SchemaPredicates } from '../ast/schemaPredicates';
 
 import {
   getTypeCondition,
@@ -13,7 +14,6 @@ import {
   getSelectionSet,
   getName,
 } from '../ast';
-import { SchemaPredicates } from '../ast/schemaPredicates';
 
 interface Context {
   store: Store;
@@ -95,6 +95,10 @@ export class SelectionIterator {
             : node;
 
           if (fragmentNode !== undefined) {
+            if (process.env.NODE_ENV !== 'production') {
+              pushDebugNode(this.typename, fragmentNode);
+            }
+
             const isMatching =
               this.context.schemaPredicates !== undefined
                 ? this.context.schemaPredicates.isInterfaceOfType(

--- a/src/operations/shared.ts
+++ b/src/operations/shared.ts
@@ -2,7 +2,7 @@ import { FieldNode, InlineFragmentNode, FragmentDefinitionNode } from 'graphql';
 import { Fragments, Variables, SelectionSet, Scalar } from '../types';
 import { Store } from '../store';
 import { joinKeys, keyOfField } from '../helpers';
-import { warning } from '../helpers/help';
+import { warn } from '../helpers/help';
 
 import {
   getTypeCondition,
@@ -32,8 +32,7 @@ const isFragmentHeuristicallyMatching = (
   const typeCondition = getTypeCondition(node);
   if (typename === typeCondition) return true;
 
-  warning(
-    false,
+  warn(
     'Heuristic Fragment Matching: A fragment is trying to match against the `' +
       typename +
       '` type, ' +

--- a/src/operations/write.ts
+++ b/src/operations/write.ts
@@ -29,7 +29,7 @@ import {
   clearStoreState,
 } from '../store';
 
-import { invariant, warning } from '../helpers/help';
+import { invariant, warn } from '../helpers/help';
 import { SelectionIterator, isScalar } from './shared';
 import { joinKeys, keyOfField } from '../helpers';
 import { SchemaPredicates } from '../ast/schemaPredicates';
@@ -179,8 +179,7 @@ export const writeFragment = (
   const names = Object.keys(fragments);
   const fragment = fragments[names[0]] as FragmentDefinitionNode;
   if (fragment === undefined) {
-    return warning(
-      false,
+    return warn(
       'writeFragment(...) was called with an empty fragment.\n' +
         'You have to call it with at least one fragment in your GraphQL document.',
       11
@@ -191,8 +190,7 @@ export const writeFragment = (
   const writeData = { __typename: typename, ...data } as Data;
   const entityKey = store.keyOfEntity(writeData);
   if (!entityKey) {
-    return warning(
-      false,
+    return warn(
       "Can't generate a key for writeFragment(...) data.\n" +
         'You have to pass an `id` or `_id` field or create a custom `keys` config for `' +
         typename +
@@ -251,8 +249,7 @@ const writeSelection = (
             ? 'scalar (number, boolean, etc)'
             : 'selection set';
 
-        warning(
-          false,
+        warn(
           'Invalid undefined: The field at `' +
             fieldKey +
             '` is `undefined`, but the GraphQL query expects a ' +
@@ -284,8 +281,7 @@ const writeSelection = (
       store.writeLink(link, fieldKey);
       store.removeRecord(fieldKey);
     } else {
-      warning(
-        false,
+      warn(
         'Invalid value: The field at `' +
           fieldKey +
           '` is a scalar (number, boolean, etc)' +
@@ -325,17 +321,16 @@ const writeField = (
 
   const entityKey = ctx.store.keyOfEntity(data);
   const key = entityKey !== null ? entityKey : parentFieldKey;
+  const typename = data.__typename;
 
   if (
-    typeof data.__typename !== 'string' ||
-    (ctx.store.keys[data.__typename] === undefined && entityKey === null)
+    ctx.store.keys[data.__typename] === undefined &&
+    entityKey === null &&
+    !typename.endsWith('Connection') &&
+    !typename.endsWith('Edge') &&
+    typename !== 'PageInfo'
   ) {
-    const typename = data.__typename;
-
-    warning(
-      typename.endsWith('Connection') ||
-        typename.endsWith('Edge') ||
-        typename === 'PageInfo',
+    warn(
       'Invalid key: The GraphQL query at the field at `' +
         parentFieldKey +
         '` has a selection set, ' +

--- a/src/operations/write.ts
+++ b/src/operations/write.ts
@@ -29,7 +29,7 @@ import {
   clearStoreState,
 } from '../store';
 
-import { invariant, warn } from '../helpers/help';
+import { invariant, warn, pushDebugNode } from '../helpers/help';
 import { SelectionIterator, isScalar } from './shared';
 import { joinKeys, keyOfField } from '../helpers';
 import { SchemaPredicates } from '../ast/schemaPredicates';
@@ -86,6 +86,10 @@ export const startWrite = (
     schemaPredicates: store.schemaPredicates,
   };
 
+  if (process.env.NODE_ENV !== 'production') {
+    pushDebugNode(operationName, operation);
+  }
+
   if (operationName === ctx.store.getRootKey('query')) {
     writeSelection(ctx, operationName, select, data);
   } else {
@@ -113,6 +117,10 @@ export const writeOptimistic = (
       'This case is unsupported and should never occur.',
     10
   );
+
+  if (process.env.NODE_ENV !== 'production') {
+    pushDebugNode(operationName, operation);
+  }
 
   const ctx: Context = {
     parentTypeName: mutationRootKey,
@@ -197,6 +205,10 @@ export const writeFragment = (
         '`.',
       12
     );
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    pushDebugNode(typename, fragment);
   }
 
   const ctx: Context = {

--- a/src/store.ts
+++ b/src/store.ts
@@ -45,14 +45,20 @@ const refValue = <T>(ref: Ref<T | null>): T => {
 export const initStoreState = (optimisticKey: null | number) => {
   currentDependencies.current = new Set();
   currentOptimisticKey.current = optimisticKey;
-  currentDebugStack.current = [];
+
+  if (process.env.NODE_ENV !== 'production') {
+    currentDebugStack.current = [];
+  }
 };
 
 // Finalise a store run by clearing its internal state
 export const clearStoreState = () => {
   currentDependencies.current = null;
   currentOptimisticKey.current = null;
-  currentDebugStack.current = [];
+
+  if (process.env.NODE_ENV !== 'production') {
+    currentDebugStack.current = [];
+  }
 };
 
 export const getCurrentDependencies = () => refValue(currentDependencies);

--- a/src/store.ts
+++ b/src/store.ts
@@ -3,6 +3,7 @@ import { createRequest } from 'urql';
 import * as Pessimism from 'pessimism';
 
 import {
+  Ref,
   Cache,
   EntityField,
   Link,
@@ -18,21 +19,17 @@ import {
 } from './types';
 
 import { joinKeys, keyOfField } from './helpers';
-import { invariant } from './helpers/help';
+import { invariant, currentDebugStack } from './helpers/help';
 import { read, readFragment } from './operations/query';
 import { writeFragment, startWrite } from './operations/write';
 import { invalidate } from './operations/invalidate';
 import { SchemaPredicates } from './ast/schemaPredicates';
 
-interface Ref<T> {
-  current: null | T;
-}
-
-const currentDependencies: Ref<Set<string>> = { current: null };
-const currentOptimisticKey: Ref<number> = { current: null };
+const currentDependencies: Ref<null | Set<string>> = { current: null };
+const currentOptimisticKey: Ref<null | number> = { current: null };
 
 // Resolve a ref value or throw when we're outside of a store run
-const refValue = <T>(ref: Ref<T>): T => {
+const refValue = <T>(ref: Ref<T | null>): T => {
   invariant(
     ref.current !== null,
     'Invalid Cache call: The cache may only be accessed or mutated during' +
@@ -48,12 +45,14 @@ const refValue = <T>(ref: Ref<T>): T => {
 export const initStoreState = (optimisticKey: null | number) => {
   currentDependencies.current = new Set();
   currentOptimisticKey.current = optimisticKey;
+  currentDebugStack.current = [];
 };
 
 // Finalise a store run by clearing its internal state
 export const clearStoreState = () => {
   currentDependencies.current = null;
   currentOptimisticKey.current = null;
+  currentDebugStack.current = [];
 };
 
 export const getCurrentDependencies = () => refValue(currentDependencies);

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,10 @@ import { DocumentNode, FragmentDefinitionNode, SelectionNode } from 'graphql';
 // Helper types
 export type NullArray<T> = Array<null | T>;
 
+export interface Ref<T> {
+  current: T;
+}
+
 // GraphQL helper types
 export type SelectionSet = ReadonlyArray<SelectionNode>;
 export interface Fragments {


### PR DESCRIPTION
This improves the debugging output by adding a small "debug trace" to it. It will list out the rough traversal of Graphcache and add it to every warning and error.

Specifically it will add operation definitions, fragment defintitions, and inline fragments to the stack and will try its best to make this output helpful, e.g.:

> Invalid undefined: The field at `Todo:1.author` is `undefined`, but the GraphQL query expects a selection set for this field.
> (Caused At: "todos" query)

or:

> Invalid value: The field at `Todo:0.writer` is a scalar (number, boolean, etc), but the GraphQL query expects a selection set for this field.
> The value will still be cached, however this may lead to undefined behavior!
> (Caused At: Unnamed mutation)

This may also encourage users to name their queries :+1:

Edit: Published for testing as `1.0.4-debug-trace` under the `@debug-trace` tag.