### PR TITLE
Small fixes to relayPagination logic

### DIFF
--- a/src/extras/relayPagination.test.ts
+++ b/src/extras/relayPagination.test.ts
@@ -682,3 +682,40 @@ it('returns an empty array of edges when the cache has zero edges stored', () =>
     edges: [],
   });
 });
+
+it('returns other fields on the same level as the edges', () => {
+  const Pagination = gql`
+    query {
+      items(first: 1) {
+        totalCount
+      }
+    }
+  `;
+
+  const store = new Store(undefined, {
+    Query: {
+      items: relayPagination(),
+    },
+  });
+
+  write(
+    store,
+    { query: Pagination },
+    {
+      __typename: 'Query',
+      items: {
+        __typename: 'ItemsConnection',
+        totalCount: 2,
+      },
+    }
+  );
+
+  const resOne = query(store, {
+    query: Pagination,
+  });
+
+  expect(resOne.data).toHaveProperty('items', {
+    __typename: 'ItemsConnection',
+    totalCount: 2,
+  });
+});

--- a/src/extras/relayPagination.test.ts
+++ b/src/extras/relayPagination.test.ts
@@ -642,3 +642,43 @@ it('prevents overlapping of pagination on different arguments', () => {
     items: null,
   });
 });
+
+it('returns an empty array of edges when the cache has zero edges stored', () => {
+  const Pagination = gql`
+    query {
+      items(first: 1) {
+        __typename
+        edges {
+          __typename
+        }
+      }
+    }
+  `;
+
+  const store = new Store(undefined, {
+    Query: {
+      items: relayPagination(),
+    },
+  });
+
+  write(
+    store,
+    { query: Pagination },
+    {
+      __typename: 'Query',
+      items: {
+        __typename: 'ItemsConnection',
+        edges: [],
+      },
+    }
+  );
+
+  const res = query(store, {
+    query: Pagination,
+  });
+
+  expect(res.data).toHaveProperty('items', {
+    __typename: 'ItemsConnection',
+    edges: [],
+  });
+});

--- a/src/extras/relayPagination.ts
+++ b/src/extras/relayPagination.ts
@@ -152,7 +152,7 @@ export const relayPagination = (params: PaginationParams = {}): Resolver => {
       return undefined;
     }
 
-    let typename = '';
+    let typename: string | null = null;
     let startEdges: NullArray<string> = [];
     let endEdges: NullArray<string> = [];
     let pageInfo: PageInfo = { ...defaultPageInfo };
@@ -208,10 +208,7 @@ export const relayPagination = (params: PaginationParams = {}): Resolver => {
       if (typename !== page.__typename) typename = page.__typename;
     }
 
-    if (
-      typeof typename !== 'string' ||
-      startEdges.length + endEdges.length === 0
-    ) {
+    if (typeof typename !== 'string') {
       return undefined;
     }
 

--- a/src/extras/relayPagination.ts
+++ b/src/extras/relayPagination.ts
@@ -92,8 +92,8 @@ const getPage = (cache: Cache, linkKey: string): Page | null => {
   if (!link) return null;
 
   const typename = cache.resolve(link, '__typename') as string;
-  const edges = cache.resolve(link, 'edges') as NullArray<string>;
-  if (typeof typename !== 'string' || !Array.isArray(edges)) {
+  const edges = (cache.resolve(link, 'edges') || []) as NullArray<string>;
+  if (typeof typename !== 'string') {
     return null;
   }
 


### PR DESCRIPTION
Hey!! 👋

This PR fixes two small issues that we've experienced when using `urql` and the `relayPagination` cache in our project (see the two commits for more info):

1. `urql` was returning a `null` response when our GraphQL endpoint returns an empty array of edges. This caused unnecessary checks for nullability in our app and some issues when detecting whether a query is still being executed vs when it's been resolved.
2. `urql` was returning a `null` response when we queried other fields different than the `edges` field on a relay-compatible connection (we use the `totalCount` field in all of our connections to query the number of total elements on that list).

(see the two tests that I've created for more detailed info about these two issues).

In order to fix these issues I've opted to avoid returning `null` in the scenarios that caused the wrong behaviour, but I'm not completely certain that this doesn't cause other issues on the cache (I'm not familiar enough with how the `urql` normalized graphcache works). Anyways, I've tried to use a patched version of `@urql/exchange-graphcache` with this changes in our app and haven't seen any issues.
