### PR TITLE
Fix viewer fields (returning to root Query) not being written

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -164,8 +164,8 @@ export class Store implements Cache {
     const { __typename: typename, id, _id } = data;
     if (!typename) {
       return null;
-    } else if (this.rootNames[typename]) {
-      return this.rootNames[typename];
+    } else if (this.rootNames[typename] !== undefined) {
+      return typename;
     }
 
     let key: string | null | void;

--- a/src/test-utils/examples-3.test.ts
+++ b/src/test-utils/examples-3.test.ts
@@ -1,0 +1,53 @@
+import gql from 'graphql-tag';
+import { query, write } from '../operations';
+import { Store } from '../store';
+
+it('allows viewer fields to overwrite the root Query data', () => {
+  const store = new Store();
+  const get = gql`
+    {
+      int
+    }
+  `;
+  const set = gql`
+    mutation {
+      mutate {
+        viewer {
+          int
+        }
+      }
+    }
+  `;
+
+  write(
+    store,
+    { query: get },
+    {
+      __typename: 'Query',
+      int: 42,
+    }
+  );
+
+  write(
+    store,
+    { query: set },
+    {
+      __typename: 'Mutation',
+      mutate: {
+        __typename: 'MutateResult',
+        viewer: {
+          __typename: 'Query',
+          int: 43,
+        },
+      },
+    }
+  );
+
+  const res = query(store, { query: get });
+
+  expect(res.partial).toBe(false);
+  expect(res.data).toEqual({
+    __typename: 'Query',
+    int: 43,
+  });
+});

--- a/src/test-utils/suite.test.ts
+++ b/src/test-utils/suite.test.ts
@@ -342,3 +342,26 @@ it('embedded objects on entities', () => {
     },
   });
 });
+
+it('nested viewer selections', () => {
+  expectCacheIntegrity({
+    query: gql`
+      {
+        __typename
+        int
+        viewer {
+          __typename
+          int
+        }
+      }
+    `,
+    data: {
+      __typename: 'Query',
+      int: 42,
+      viewer: {
+        __typename: 'Query',
+        int: 42,
+      },
+    },
+  });
+});


### PR DESCRIPTION
When we're dealing with a result (for instance from a `mutation`) that has a viewer field returning to root `Query` data, we weren't generating a correct `entityKey`, and hence not resolving or writing nested `Query` data.

More can be seen in the new test for this: https://github.com/FormidableLabs/urql-exchange-graphcache/pull/116/files#diff-03339b8ad25c28b296fcd84ea5e664dcR31-R44