### PR TITLE
Replace Pessimism with mutable store to prevent excessive GC work

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     }
   },
   "dependencies": {
-    "pessimism": "^1.1.4",
     "wonka": "^3.2.1"
   },
   "peerDependencies": {

--- a/src/map.ts
+++ b/src/map.ts
@@ -1,0 +1,59 @@
+type Data<T> = Map<string, T>;
+type OptimisticData<T> = { [optimisticKey: number]: Data<T | undefined> };
+
+export interface KVMap<T> {
+  optimistic: OptimisticData<T>;
+  base: Data<T>;
+}
+
+export const make = <T>(): KVMap<T> => ({
+  optimistic: Object.create(null),
+  base: new Map(),
+});
+
+export const set = <T>(
+  map: KVMap<T>,
+  key: string,
+  value: T,
+  optimisticKey: number
+): KVMap<T> => {
+  if (optimisticKey !== 0) {
+    if (map.optimistic[optimisticKey] === undefined)
+      map.optimistic[optimisticKey] = new Map();
+    map.optimistic[optimisticKey].set(key, value);
+  } else {
+    map.base.set(key, value);
+  }
+
+  return map;
+};
+
+export const remove = <T>(
+  map: KVMap<T>,
+  key: string,
+  optimisticKey: number
+): KVMap<T> => {
+  if (optimisticKey !== 0) {
+    if (map.optimistic[optimisticKey] === undefined)
+      map.optimistic[optimisticKey] = new Map();
+    map.optimistic[optimisticKey].set(key, undefined);
+  } else {
+    map.base.delete(key);
+  }
+
+  return map;
+};
+
+export const clear = <T>(map: KVMap<T>, optimisticKey: number): KVMap<T> => {
+  delete map.optimistic[optimisticKey];
+  return map;
+};
+
+export const get = <T>(map: KVMap<T>, key: string): T | undefined => {
+  for (const optimisticKey in map.optimistic) {
+    const optimistic = map.optimistic[optimisticKey];
+    if (optimistic.has(key)) return optimistic.get(key);
+  }
+
+  return map.base.get(key);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4392,11 +4392,6 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-pessimism@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/pessimism/-/pessimism-1.1.4.tgz#9a83bde165a773bb65a0e77551a9960a28df0741"
-  integrity sha512-MZypBlwcfyd+v53cUeY4188rX9PPZYe7UfdBxenfzVaeW64UX4yGk+xNUp6FTBeqQfRw1m9z2eLFGHQrZp0gJw==
-
 picomatch@^2.0.5:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"


### PR DESCRIPTION
Let's experiment with a version of `@urql/exchange-graphcache` that doesn't use the HAMT-based Pessimism data structure. This will reduce the amount of work the GC has to do by 60%, which is quite dramatic, so it may not change much in terms of performance in the short term, but in real-world apps it may make quite the difference.

A test version has been published to npm as `@urql/exchange-graphcache@fast`, version `1.2.2-fast`