### PR TITLE
persistant layer for graphcache

### DIFF
--- a/src/cacheExchange.ts
+++ b/src/cacheExchange.ts
@@ -8,7 +8,22 @@ import {
 } from 'urql/core';
 
 import { IntrospectionQuery } from 'graphql';
-import { filter, map, merge, pipe, share, tap } from 'wonka';
+import {
+  filter,
+  map,
+  merge,
+  pipe,
+  share,
+  tap,
+  fromPromise,
+  fromArray,
+  buffer,
+  take,
+  mergeMap,
+  concat,
+  empty,
+  Source,
+} from 'wonka';
 import { query, write, writeOptimistic } from './operations';
 import { SchemaPredicates } from './ast';
 import { makeDict, Store, clearOptimistic } from './store';
@@ -18,6 +33,7 @@ import {
   ResolverConfig,
   OptimisticMutationConfig,
   KeyingConfig,
+  StorageAdapter,
 } from './types';
 
 type OperationResultWithMeta = OperationResult & {
@@ -87,6 +103,7 @@ export interface CacheExchangeOpts {
   optimistic?: OptimisticMutationConfig;
   keys?: KeyingConfig;
   schema?: IntrospectionQuery;
+  storage?: StorageAdapter;
 }
 
 export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
@@ -102,6 +119,13 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
     opts.optimistic,
     opts.keys
   );
+
+  let hydration: void | Promise<void>;
+  if (opts.storage) {
+    hydration = opts.storage.read().then(data => {
+      store.hydrateData(data, (opts as any).storage);
+    });
+  }
 
   const optimisticKeys = new Set();
   const ops: OperationMap = new Map();
@@ -243,8 +267,21 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
   };
 
   return ops$ => {
-    const sharedOps$ = pipe(
-      ops$,
+    const sharedOps$ = pipe(ops$, share);
+
+    // Buffer operations while waiting on hydration to finish
+    // If no hydration takes place we replace this stream with an empty one
+    const bufferedOps$ = hydration
+      ? pipe(
+          sharedOps$,
+          buffer(fromPromise(hydration)),
+          take(1),
+          mergeMap(fromArray)
+        )
+      : (empty as Source<Operation>);
+
+    const inputOps$ = pipe(
+      concat([bufferedOps$, sharedOps$]),
       map(addTypeNames),
       tap(optimisticUpdate),
       share
@@ -252,7 +289,7 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
 
     // Filter by operations that are cacheable and attempt to query them from the cache
     const cache$ = pipe(
-      sharedOps$,
+      inputOps$,
       filter(op => isCacheableQuery(op)),
       map(operationResultFromCache),
       share
@@ -302,7 +339,7 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
       forward(
         merge([
           pipe(
-            sharedOps$,
+            inputOps$,
             filter(op => !isCacheableQuery(op))
           ),
           cacheOps$,

--- a/src/cacheExchange.ts
+++ b/src/cacheExchange.ts
@@ -122,8 +122,9 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
 
   let hydration: void | Promise<void>;
   if (opts.storage) {
-    hydration = opts.storage.read().then(data => {
-      store.hydrateData(data, (opts as any).storage);
+    const storage = opts.storage;
+    hydration = storage.read().then(data => {
+      store.hydrateData(data, storage);
     });
   }
 

--- a/src/store/__snapshots__/store.test.ts.snap
+++ b/src/store/__snapshots__/store.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Store with storage should be able to store and rehydrate data 1`] = `
+Object {
+  "l|Query.appointment({\\"id\\":\\"1\\"})": "Appointment:1",
+  "r|Appointment:1.__typename": "Appointment",
+  "r|Appointment:1.id": "1",
+  "r|Appointment:1.info": "urql meeting",
+  "r|Query.__typename": "Query",
+  "r|Query.appointment({\\"id\\":\\"1\\"})": undefined,
+}
+`;

--- a/src/store/data.ts
+++ b/src/store/data.ts
@@ -279,7 +279,7 @@ export const gc = (data: InMemoryData) => {
       data.records.base.delete(entityKey);
       data.gcBatch.delete(entityKey);
       if (storage.current) {
-        storage.current.remove(prefixKey('r', entityKey));
+        persistanceBatch[prefixKey('r', entityKey)] = undefined;
       }
 
       // Delete all the entity's links, but also update the reference count
@@ -288,7 +288,7 @@ export const gc = (data: InMemoryData) => {
       if (linkNode !== undefined) {
         data.links.base.delete(entityKey);
         if (storage.current) {
-          storage.current.remove(prefixKey('l', entityKey));
+          persistanceBatch[prefixKey('l', entityKey)] = undefined;
         }
         for (const key in linkNode) {
           updateRCForLink(data.gcBatch, data.refCount, linkNode[key], -1);

--- a/src/store/data.ts
+++ b/src/store/data.ts
@@ -27,7 +27,7 @@ export interface InMemoryData {
   refLock: OptimisticMap<Dict<number>>;
   records: NodeMap<EntityField>;
   links: NodeMap<Link>;
-  storage?: StorageAdapter;
+  storage: StorageAdapter | null;
 }
 
 let currentData: null | InMemoryData = null;
@@ -103,6 +103,7 @@ export const make = (queryRootKey: string): InMemoryData => ({
   refLock: makeDict(),
   links: makeNodeMap(),
   records: makeNodeMap(),
+  storage: null,
 });
 
 /** Adds a node value to a NodeMap (taking optimistic values into account */

--- a/src/store/keys.ts
+++ b/src/store/keys.ts
@@ -23,3 +23,6 @@ export const fieldInfoOfKey = (fieldKey: string): FieldInfo => {
 
 export const joinKeys = (parentKey: string, key: string) =>
   `${parentKey}.${key}`;
+
+/** Prefix key with its owner type Link / Record */
+export const prefixKey = (owner: 'l' | 'r', key: string) => `${owner}|${key}`;

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -424,7 +424,6 @@ describe('Store with storage', () => {
     const storage: StorageAdapter = {
       read: jest.fn(),
       write: jest.fn(),
-      remove: jest.fn(),
     };
     let store = new Store();
 

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
 
-import { Data } from '../types';
+import { Data, StorageAdapter } from '../types';
 import { query } from '../operations/query';
 import { write, writeOptimistic } from '../operations/write';
 import * as InMemoryData from './data';
@@ -403,5 +403,58 @@ describe('Store with OptimisticMutationConfig', () => {
       __typename: 'Query',
       todos: todosData.todos,
     });
+  });
+});
+
+describe('Store with storage', () => {
+  const expectedData = {
+    __typename: 'Query',
+    appointment: {
+      __typename: 'Appointment',
+      id: '1',
+      info: 'urql meeting',
+    },
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  it('should be able to store and rehydrate data', () => {
+    const storage: StorageAdapter = {
+      read: jest.fn(),
+      write: jest.fn(),
+      remove: jest.fn(),
+    };
+    let store = new Store();
+
+    store.hydrateData(Object.create(null), storage);
+
+    write(
+      store,
+      {
+        query: Appointment,
+        variables: { id: '1' },
+      },
+      expectedData
+    );
+
+    expect(storage.write).not.toHaveBeenCalled();
+
+    jest.runAllTimers();
+    expect(storage.write).toHaveBeenCalled();
+
+    const serialisedStore = (storage.write as any).mock.calls[0][0];
+    expect(serialisedStore).toMatchSnapshot();
+
+    store = new Store();
+    store.hydrateData(serialisedStore, storage);
+
+    const { data } = query(store, {
+      query: Appointment,
+      variables: { id: '1' },
+    });
+
+    expect(data).toEqual(expectedData);
   });
 });

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -189,20 +189,20 @@ export class Store implements Cache {
   }
 
   hydrateData(data: object, adapter: StorageAdapter) {
-    InMemoryData.storage.current = adapter;
     InMemoryData.initDataState(this.data, 0);
     for (const key in data) {
       const entityKey = key.slice(2, key.indexOf('.'));
       const fieldKey = key.slice(key.indexOf('.') + 1);
       switch (key.charCodeAt(0)) {
         case 108:
-          InMemoryData.writeLink(entityKey, fieldKey, data[key], true);
+          InMemoryData.writeLink(entityKey, fieldKey, data[key]);
           break;
         case 114:
-          InMemoryData.writeRecord(entityKey, fieldKey, data[key], true);
+          InMemoryData.writeRecord(entityKey, fieldKey, data[key]);
           break;
       }
     }
     InMemoryData.clearDataState();
+    this.data.storage = adapter;
   }
 }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -12,6 +12,7 @@ import {
   UpdatesConfig,
   OptimisticMutationConfig,
   KeyingConfig,
+  StorageAdapter,
 } from '../types';
 
 import { read, readFragment } from '../operations/query';
@@ -185,5 +186,23 @@ export class Store implements Cache {
     variables?: Variables
   ): void {
     writeFragment(this, dataFragment, data, variables);
+  }
+
+  hydrateData(data: object, adapter: StorageAdapter) {
+    InMemoryData.storage.current = adapter;
+    InMemoryData.initDataState(this.data, 0);
+    for (const key in data) {
+      const entityKey = key.slice(2, key.indexOf('.'));
+      const fieldKey = key.slice(key.indexOf('.') + 1);
+      switch (key.charCodeAt(0)) {
+        case 108:
+          InMemoryData.writeLink(entityKey, fieldKey, data[key], true);
+          break;
+        case 114:
+          InMemoryData.writeRecord(entityKey, fieldKey, data[key], true);
+          break;
+      }
+    }
+    InMemoryData.clearDataState();
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,6 +172,18 @@ export interface KeyingConfig {
   [typename: string]: KeyGenerator;
 }
 
+export type SerializedEntry = EntityField | Connection[] | Link;
+
+export interface SerializedEntries {
+  [key: string]: SerializedEntry;
+}
+
+export interface StorageAdapter {
+  read(): Promise<SerializedEntries>;
+  remove(key: string): Promise<void>;
+  write(data: SerializedEntries): Promise<void>;
+}
+
 export type ErrorCode =
   | 1
   | 2

--- a/src/types.ts
+++ b/src/types.ts
@@ -180,7 +180,6 @@ export interface SerializedEntries {
 
 export interface StorageAdapter {
   read(): Promise<SerializedEntries>;
-  remove(key: string): Promise<void>;
   write(data: SerializedEntries): Promise<void>;
 }
 


### PR DESCRIPTION
Due to changing a lot of internals I found that making this implementation again gave profit, it's smaller :tada:

This PR adds the ability to supply two async functions to the cache, these will function as an adapter for the persistence layer of your choice.

```
cache({ storage: { read: idb.read, set: idb.set })
```

--> will for instance write to an indexedDb and read from it, first time you start the cache it will buffer every incoming operation until the store has been hydrated by the data from your persistence layer.

During gc we perform `set(key, undefined)` on garbage collected fields/links to avoid our offline storage from heaping up.

> TODO: evaluate if this is sufficient

This is a first-step to a fully offline-compatible cache