### PR TITLE
Add per-field deletion for persistence batch during GC

### DIFF
--- a/src/cacheExchange.ts
+++ b/src/cacheExchange.ts
@@ -1,3 +1,5 @@
+import { IntrospectionQuery } from 'graphql';
+
 import {
   Exchange,
   formatDocument,
@@ -7,7 +9,6 @@ import {
   CacheOutcome,
 } from 'urql/core';
 
-import { IntrospectionQuery } from 'graphql';
 import {
   filter,
   map,
@@ -24,8 +25,10 @@ import {
   empty,
   Source,
 } from 'wonka';
+
 import { query, write, writeOptimistic } from './operations';
 import { SchemaPredicates } from './ast';
+import { hydrateData } from './store/data';
 import { makeDict, Store, clearOptimistic } from './store';
 
 import {
@@ -123,8 +126,8 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
   let hydration: void | Promise<void>;
   if (opts.storage) {
     const storage = opts.storage;
-    hydration = storage.read().then(data => {
-      store.hydrateData(data, storage);
+    hydration = storage.read().then(entries => {
+      hydrateData(store.data, storage, entries);
     });
   }
 

--- a/src/store/__snapshots__/store.test.ts.snap
+++ b/src/store/__snapshots__/store.test.ts.snap
@@ -10,3 +10,14 @@ Object {
   "r|Query.appointment({\\"id\\":\\"1\\"})": undefined,
 }
 `;
+
+exports[`Store with storage writes removals based on GC to storage 1`] = `
+Object {
+  "l|Query.appointment({\\"id\\":\\"1\\"})": undefined,
+  "r|Appointment:1.__typename": undefined,
+  "r|Appointment:1.id": undefined,
+  "r|Appointment:1.info": undefined,
+  "r|Query.__typename": "Query",
+  "r|Query.appointment({\\"id\\":\\"1\\"})": undefined,
+}
+`;

--- a/src/store/data.ts
+++ b/src/store/data.ts
@@ -289,9 +289,8 @@ export const gc = (data: InMemoryData) => {
         data.records.base.delete(entityKey);
         if (data.storage) {
           for (const fieldKey in recordsNode) {
-            currentPersistenceBatch[
-              prefixKey('r', joinKeys(entityKey, fieldKey))
-            ] = undefined;
+            const key = prefixKey('r', joinKeys(entityKey, fieldKey));
+            currentPersistenceBatch[key] = undefined;
           }
         }
       }
@@ -304,9 +303,8 @@ export const gc = (data: InMemoryData) => {
         for (const fieldKey in linkNode) {
           // Delete all links from the persistence layer if one is present
           if (data.storage) {
-            currentPersistenceBatch[
-              prefixKey('l', joinKeys(entityKey, fieldKey))
-            ] = undefined;
+            const key = prefixKey('l', joinKeys(entityKey, fieldKey));
+            currentPersistenceBatch[key] = undefined;
           }
 
           updateRCForLink(data.gcBatch, data.refCount, linkNode[fieldKey], -1);

--- a/src/store/data.ts
+++ b/src/store/data.ts
@@ -427,3 +427,26 @@ export const inspectFields = (entityKey: string): FieldInfo[] => {
   extractNodeMapFields(fieldInfos, seenFieldKeys, entityKey, records);
   return fieldInfos;
 };
+
+export const hydrateData = (
+  data: InMemoryData,
+  storage: StorageAdapter,
+  entries: SerializedEntries
+) => {
+  initDataState(data, 0);
+  for (const key in entries) {
+    const dotIndex = key.indexOf('.');
+    const entityKey = key.slice(2, dotIndex);
+    const fieldKey = key.slice(dotIndex + 1);
+    switch (key.charCodeAt(0)) {
+      case 108:
+        writeLink(entityKey, fieldKey, entries[key] as Link);
+        break;
+      case 114:
+        writeRecord(entityKey, fieldKey, entries[key]);
+        break;
+    }
+  }
+  clearDataState();
+  data.storage = storage;
+};

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -457,7 +457,7 @@ describe('Store with storage', () => {
     expect(data).toEqual(expectedData);
   });
 
-  it.only('writes removals based on GC to storage', () => {
+  it('writes removals based on GC to storage', () => {
     const storage: StorageAdapter = {
       read: jest.fn(),
       write: jest.fn(),

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -425,9 +425,9 @@ describe('Store with storage', () => {
       read: jest.fn(),
       write: jest.fn(),
     };
-    let store = new Store();
 
-    store.hydrateData(Object.create(null), storage);
+    let store = new Store();
+    InMemoryData.hydrateData(store.data, storage, Object.create(null));
 
     write(
       store,
@@ -447,7 +447,7 @@ describe('Store with storage', () => {
     expect(serialisedStore).toMatchSnapshot();
 
     store = new Store();
-    store.hydrateData(serialisedStore, storage);
+    InMemoryData.hydrateData(store.data, storage, serialisedStore);
 
     const { data } = query(store, {
       query: Appointment,
@@ -455,5 +455,39 @@ describe('Store with storage', () => {
     });
 
     expect(data).toEqual(expectedData);
+  });
+
+  it.only('writes removals based on GC to storage', () => {
+    const storage: StorageAdapter = {
+      read: jest.fn(),
+      write: jest.fn(),
+    };
+
+    const store = new Store();
+    InMemoryData.hydrateData(store.data, storage, Object.create(null));
+
+    write(
+      store,
+      {
+        query: Appointment,
+        variables: { id: '1' },
+      },
+      expectedData
+    );
+
+    InMemoryData.initDataState(store.data, 0);
+    InMemoryData.writeLink(
+      'Query',
+      store.keyOfField('appointment', { id: '1' }),
+      undefined
+    );
+    InMemoryData.gc(store.data);
+    InMemoryData.clearDataState();
+
+    jest.runAllTimers();
+
+    expect(storage.write).toHaveBeenCalled();
+    const serialisedStore = (storage.write as any).mock.calls[0][0];
+    expect(serialisedStore).toMatchSnapshot();
   });
 });

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -12,7 +12,6 @@ import {
   UpdatesConfig,
   OptimisticMutationConfig,
   KeyingConfig,
-  StorageAdapter,
 } from '../types';
 
 import { read, readFragment } from '../operations/query';
@@ -186,23 +185,5 @@ export class Store implements Cache {
     variables?: Variables
   ): void {
     writeFragment(this, dataFragment, data, variables);
-  }
-
-  hydrateData(data: object, adapter: StorageAdapter) {
-    InMemoryData.initDataState(this.data, 0);
-    for (const key in data) {
-      const entityKey = key.slice(2, key.indexOf('.'));
-      const fieldKey = key.slice(key.indexOf('.') + 1);
-      switch (key.charCodeAt(0)) {
-        case 108:
-          InMemoryData.writeLink(entityKey, fieldKey, data[key]);
-          break;
-        case 114:
-          InMemoryData.writeRecord(entityKey, fieldKey, data[key]);
-          break;
-      }
-    }
-    InMemoryData.clearDataState();
-    this.data.storage = adapter;
   }
 }


### PR DESCRIPTION
- Add per-field deletion during GC on persistence batch
- Move to `data.persistenceBatch`
- Prevent deferred `storage.write` from being scheduled twice

| `v2.0.0` | `master` before persistence (#134) | `master` after persistence | This PR |
| --------------- | --------------- | -------------- | ------- |
| `6.85kB` | `6.68kB` | `6.94kB` | `7kB` |