### PR TITLE
RFC: Remove impossible case of scalars where links are expected

### DIFF
--- a/benchmark/suite.js
+++ b/benchmark/suite.js
@@ -482,12 +482,12 @@ suite('100 entries complex write', () => {
   benchmark('apollo', () => {
     return apolloCache.writeQuery({
       query: AuthorQuery,
-      data: { todos: hundredEntriesComplex },
+      data: { authors: hundredEntriesComplex },
     });
   });
 
   benchmark('urql', () => {
-    return write(urqlStore, { query: AuthorQuery }, { todos: hundredEntriesComplex });
+    return write(urqlStore, { query: AuthorQuery }, { authors: hundredEntriesComplex });
   });
 });
 
@@ -498,12 +498,12 @@ suite('1,000 entries complex write', () => {
   benchmark('apollo', () => {
     return apolloCache.writeQuery({
       query: AuthorQuery,
-      data: { todos: thousandEntriesComplex },
+      data: { authors: thousandEntriesComplex },
     });
   });
 
   benchmark('urql', () => {
-    return write(urqlStore, { query: AuthorQuery }, { todos: thousandEntriesComplex });
+    return write(urqlStore, { query: AuthorQuery }, { authors: thousandEntriesComplex });
   });
 });
 
@@ -514,7 +514,7 @@ suite('10,000 entries complex write', () => {
   benchmark('apollo', () => {
     return apolloCache.writeQuery({
       query: AuthorQuery,
-      data: { todos: tenThousandEntriesComplex },
+      data: { authors: tenThousandEntriesComplex },
     });
   });
 
@@ -522,7 +522,7 @@ suite('10,000 entries complex write', () => {
     return write(
       urqlStore,
       { query: AuthorQuery },
-      { todos: tenThousandEntriesComplex }
+      { authors: tenThousandEntriesComplex }
     );
   });
 });

--- a/docs/help.md
+++ b/docs/help.md
@@ -189,16 +189,6 @@ As data is written to the cache, this warning is issued when `undefined` is enco
 GraphQL results should never contain an `undefined` value, so this warning will let you
 know which part of your result did contain `undefined`.
 
-## (14) Invalid undefined <a id="14"></a>
-
-> Invalid value: The field at `???` is a scalar (number, boolean, etc), but the
-> GraphQL query expects a selection set for this field.
-> The value will still be cached, however this may lead to undefined behavior!
-
-This warning occurs when a scalar is being written to a field that has
-a selection set. This may happen when an object without a `__typename` field
-is encountered on a GraphQL result.
-
 ## (15) Invalid key <a id="15"></a>
 
 > Invalid key: The GraphQL query at the field at `???` has a selection set,

--- a/src/operations/query.ts
+++ b/src/operations/query.ts
@@ -34,7 +34,7 @@ import {
 
 import * as InMemoryData from '../store/data';
 import { warn, pushDebugNode } from '../helpers/help';
-import { SelectionIterator, isScalar } from './shared';
+import { SelectionIterator, ensureData } from './shared';
 import { SchemaPredicates } from '../ast';
 
 export interface QueryResult {
@@ -114,22 +114,17 @@ const readRoot = (
     return originalData;
   }
 
+  const iter = new SelectionIterator(entityKey, entityKey, select, ctx);
   const data = makeDict();
   data.__typename = originalData.__typename;
-
-  const iter = new SelectionIterator(entityKey, entityKey, select, ctx);
 
   let node: FieldNode | void;
   while ((node = iter.next()) !== undefined) {
     const fieldAlias = getFieldAlias(node);
     const fieldValue = originalData[fieldAlias];
-
-    if (
-      node.selectionSet !== undefined &&
-      fieldValue !== null &&
-      !isScalar(fieldValue)
-    ) {
-      data[fieldAlias] = readRootField(ctx, getSelectionSet(node), fieldValue);
+    if (node.selectionSet !== undefined && fieldValue !== null) {
+      const fieldData = ensureData(fieldValue);
+      data[fieldAlias] = readRootField(ctx, getSelectionSet(node), fieldData);
     } else {
       data[fieldAlias] = fieldValue;
     }

--- a/src/operations/shared.ts
+++ b/src/operations/shared.ts
@@ -140,6 +140,5 @@ export class SelectionIterator {
   }
 }
 
-export const ensureData = (x: DataField): Data | NullArray<Data> | null => {
-  return x as Data | NullArray<Data>;
-};
+export const ensureData = (x: DataField): Data | NullArray<Data> | null =>
+  x === undefined ? null : (x as Data | NullArray<Data>);

--- a/src/operations/shared.ts
+++ b/src/operations/shared.ts
@@ -3,7 +3,15 @@ import { FieldNode, InlineFragmentNode, FragmentDefinitionNode } from 'graphql';
 import { warn, pushDebugNode } from '../helpers/help';
 import { hasField } from '../store/data';
 import { Store, keyOfField } from '../store';
-import { Fragments, Variables, SelectionSet, Scalar } from '../types';
+
+import {
+  Fragments,
+  Variables,
+  SelectionSet,
+  DataField,
+  NullArray,
+  Data,
+} from '../types';
 
 import {
   SchemaPredicates,
@@ -132,16 +140,6 @@ export class SelectionIterator {
   }
 }
 
-// Without a typename field on Data or Data[] the result must be a scalar
-// This effectively prevents us from writing Data into the store that
-// doesn't have a __typename field
-export const isScalar = (x: any): x is Scalar | Scalar[] => {
-  if (Array.isArray(x)) {
-    return x.some(isScalar);
-  }
-
-  return (
-    typeof x !== 'object' ||
-    (x !== null && typeof (x as any).__typename !== 'string')
-  );
+export const ensureData = (x: DataField): Data | NullArray<Data> | null => {
+  return x as Data | NullArray<Data>;
 };

--- a/src/operations/write.test.ts
+++ b/src/operations/write.test.ts
@@ -118,7 +118,7 @@ describe('Query', () => {
       }
     );
     // Because of us indicating Todo:Writer as a scalar
-    expect(console.warn).toHaveBeenCalledTimes(2);
+    expect(console.warn).toHaveBeenCalledTimes(1);
     write(
       store,
       { query: INVALID_TODO_QUERY },
@@ -135,7 +135,7 @@ describe('Query', () => {
       }
     );
 
-    expect(console.warn).toHaveBeenCalledTimes(2);
+    expect(console.warn).toHaveBeenCalledTimes(1);
     expect((console.warn as any).mock.calls[0][0]).toMatch(/writer/);
   });
 
@@ -150,7 +150,7 @@ describe('Query', () => {
     // This should not overwrite the field
     write(store, { query }, { field: undefined } as any);
     // Because of us writing an undefined field
-    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledTimes(2);
     expect((console.warn as any).mock.calls[0][0]).toMatch(/undefined/);
 
     InMemoryData.initDataState(store.data, 0);

--- a/src/store/__snapshots__/store.test.ts.snap
+++ b/src/store/__snapshots__/store.test.ts.snap
@@ -7,7 +7,6 @@ Object {
   "r|Appointment:1.id": "1",
   "r|Appointment:1.info": "urql meeting",
   "r|Query.__typename": "Query",
-  "r|Query.appointment({\\"id\\":\\"1\\"})": undefined,
 }
 `;
 
@@ -18,6 +17,5 @@ Object {
   "r|Appointment:1.id": undefined,
   "r|Appointment:1.info": undefined,
   "r|Query.__typename": "Query",
-  "r|Query.appointment({\\"id\\":\\"1\\"})": undefined,
 }
 `;

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -260,6 +260,7 @@ describe('Store with OptimisticMutationConfig', () => {
           text: 'Test updateQuery',
           complete: false,
           author: {
+            __typename: 'Author',
             id: '3',
             name: 'Andy',
           },
@@ -282,6 +283,7 @@ describe('Store with OptimisticMutationConfig', () => {
           text: 'Test updateQuery',
           complete: false,
           author: {
+            __typename: 'Author',
             id: '3',
             name: 'Andy',
           },

--- a/src/test-utils/suite.test.ts
+++ b/src/test-utils/suite.test.ts
@@ -100,26 +100,6 @@ it('non-keyable entity on query', () => {
   });
 });
 
-it('invalid entity on query', () => {
-  expectCacheIntegrity({
-    query: gql`
-      {
-        __typename
-        item {
-          __typename
-          id
-          name
-        }
-      }
-    `,
-    // This entity comes back with an invalid typename (for some reason or another)
-    data: {
-      __typename: 'Query',
-      item: { __typename: null, id: '123', name: 'Test' },
-    },
-  });
-});
-
 it('non-IDable entity on query', () => {
   expectCacheIntegrity({
     query: gql`
@@ -226,7 +206,10 @@ it('entity list on query', () => {
     `,
     data: {
       __typename: 'Query',
-      items: [{ __typename: 'Item', id: 1 }, { __typename: 'Item', id: 2 }],
+      items: [
+        { __typename: 'Item', id: 1 },
+        { __typename: 'Item', id: 2 },
+      ],
     },
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -197,7 +197,6 @@ export type ErrorCode =
   | 11
   | 12
   | 13
-  | 14
   | 15
   | 16
   | 17


### PR DESCRIPTION
We have to validate whether this is truly not expected in real apps, but it shouldn't be a possible case. If this is a correct assumption, then this is *not* a breaking change.

This removes the case of scalars being encountered when a selection set is set on the node we're traversing, either during read or write. This case manifests itself by encountering a value that isn't null, but also isn't an object (or an array of such) with a `__typename` field.

This should be an impossible case outside of test scenarios since selection sets always imply `null` or data.

The bundlesize is unchanged, which makes me think, maybe this is irrelevant.