### PR TITLE
Fix #unwrapType by recursively unwrapping to find root scalar or composite type

### DIFF
--- a/src/ast/node.test.ts
+++ b/src/ast/node.test.ts
@@ -1,0 +1,46 @@
+import { unwrapType } from './';
+import { GraphQLScalarType, GraphQLNonNull, GraphQLList } from 'graphql';
+
+describe('unwrapType', () => {
+  it('Should return the type if not wrapped', () => {
+    const type = new GraphQLScalarType({
+      name: 'String',
+      serialize: () => null,
+    });
+
+    expect(unwrapType(type)).toBe(type);
+  });
+
+  it('Should unwrap non-nullable types', () => {
+    const scalar = new GraphQLScalarType({
+      name: 'MyScalar',
+      serialize: () => null,
+    });
+    const type = new GraphQLNonNull(scalar);
+
+    expect(unwrapType(type)).toBe(scalar);
+  });
+
+  it('Should unwrap list types', () => {
+    const scalar = new GraphQLScalarType({
+      name: 'MyScalar',
+      serialize: () => null,
+    });
+    const type = new GraphQLList(scalar);
+
+    expect(unwrapType(type)).toBe(scalar);
+  });
+
+  it('Should unwrap nested types', () => {
+    const scalar = new GraphQLScalarType({
+      name: 'MyScalar',
+      serialize: () => null,
+    });
+
+    const nonNullList = new GraphQLNonNull(scalar);
+
+    const type = new GraphQLList(nonNullList);
+
+    expect(unwrapType(type)).toBe(scalar);
+  });
+});

--- a/src/ast/node.ts
+++ b/src/ast/node.ts
@@ -8,8 +8,7 @@ import {
   FragmentDefinitionNode,
   GraphQLOutputType,
   Kind,
-  isListType,
-  isNonNullType,
+  isWrappingType,
 } from 'graphql';
 
 import { SelectionSet, GraphQLFlatType } from '../types';
@@ -47,7 +46,9 @@ export const isInlineFragment = (
 export const unwrapType = (
   type: null | undefined | GraphQLOutputType
 ): GraphQLFlatType | null => {
-  return type && (isListType(type) || isNonNullType(type))
-    ? type.ofType
-    : type || null;
+  if (isWrappingType(type)) {
+    return unwrapType(type.ofType);
+  }
+
+  return type || null;
 };

--- a/src/populateExchange.ts
+++ b/src/populateExchange.ts
@@ -9,8 +9,6 @@ import {
   FragmentSpreadNode,
   NameNode,
   ASTNode,
-  isUnionType,
-  isInterfaceType,
   isCompositeType,
   isAbstractType,
   Kind,
@@ -282,9 +280,7 @@ const getTypes = (schema: GraphQLSchema, typeInfo: TypeInfo) => {
     return [];
   }
 
-  return isInterfaceType(type) || isUnionType(type)
-    ? schema.getPossibleTypes(type)
-    : [type];
+  return isAbstractType(type) ? schema.getPossibleTypes(type) : [type];
 };
 
 /** Get name of non-abstract type for adding to 'typeFragments'. */


### PR DESCRIPTION
```gql
type Query {
	threads: [Thread!]
}

type Thread {
	id: ID!
	title: String!
}
```

Given the schema above the following `threads` selection set would be incorrectly identified as a list.

```gql
query {
	threads {
		id
		title
	}
}
```

This change recurses through the linked types, unwrapping each one until the root   non-wrapping type is found.