### PR TITLE
Fix pagination with different param sets

### DIFF
--- a/src/extras/relayPagination.ts
+++ b/src/extras/relayPagination.ts
@@ -84,6 +84,19 @@ const compareArgs = (
     }
   }
 
+  for (const key in fieldArgs) {
+    if (
+      key === 'first' ||
+      key === 'last' ||
+      key === 'after' ||
+      key === 'before'
+    ) {
+      continue;
+    }
+
+    if (!(key in connectionArgs)) return false;
+  }
+
   return true;
 };
 

--- a/src/extras/simplePagination.test.ts
+++ b/src/extras/simplePagination.test.ts
@@ -127,6 +127,55 @@ it('handles duplicates', () => {
   });
 });
 
+it('should not return previous result when adding a parameter', () => {
+  const Pagination = gql`
+    query($skip: Number, $limit: Number, $filter: String) {
+      persons(skip: $skip, limit: $limit, filter: $filter) {
+        __typename
+        id
+        name
+      }
+    }
+  `;
+
+  const store = new Store(undefined, {
+    Query: {
+      persons: simplePagination(),
+    },
+  });
+
+  const pageOne = {
+    __typename: 'Query',
+    persons: [
+      { id: 1, name: 'Jovi', __typename: 'Person' },
+      { id: 2, name: 'Phil', __typename: 'Person' },
+      { id: 3, name: 'Andy', __typename: 'Person' },
+    ],
+  };
+
+  const emptyPage = {
+    __typename: 'Query',
+    persons: [],
+  };
+
+  write(
+    store,
+    { query: Pagination, variables: { skip: 0, limit: 3 } },
+    pageOne
+  );
+  write(
+    store,
+    { query: Pagination, variables: { skip: 0, limit: 3, filter: 'b' } },
+    emptyPage
+  );
+
+  const res = query(store, {
+    query: Pagination,
+    variables: { skip: 0, limit: 3, filter: 'b' },
+  });
+  expect(res.data).toEqual({ __typename: 'Query', persons: [] });
+});
+
 it('should preserve the correct order', () => {
   const Pagination = gql`
     query($skip: Number, $limit: Number) {

--- a/src/extras/simplePagination.ts
+++ b/src/extras/simplePagination.ts
@@ -33,6 +33,13 @@ export const simplePagination = ({
       }
     }
 
+    for (const key in fieldArgs) {
+      if (key === offsetArgument || key === limitArgument) {
+        continue;
+      }
+      if (!(key in connectionArgs)) return false;
+    }
+
     return true;
   };
 


### PR DESCRIPTION
ensures we do not add previous results when adding parameters, in this case connectionArgs had less parameters than our fieldArgs resulting in erroneous data

I was made aware of this issue on slack