### PR TITLE
Include prepare:extras in build step for pika

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "clean": "rimraf ./dist ./node_modules/.cache",
     "build": "rollup -c rollup.config.js",
-    "postbuild": "yarn prepare:extras",
+    "postbuild": "run-s prepare:extras",
     "watch": "rollup -w -c rollup.config.js",
     "check": "tsc --noEmit",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
   "sideEffects": false,
   "scripts": {
     "clean": "rimraf ./dist ./node_modules/.cache",
-    "build": "rollup -c rollup.config.js",
+    "build": "rollup -c rollup.config.js && yarn prepare:extras",
     "watch": "rollup -w -c rollup.config.js",
     "check": "tsc --noEmit",
     "test": "jest",
     "coverage": "jest --coverage",
     "lint": "eslint . --ext .ts,.tsx",
     "prepare:extras": "./scripts/prepare-extras.js",
-    "prepublishOnly": "run-s clean test build prepare:extras",
+    "prepublishOnly": "run-s clean test build",
     "codecov": "codecov"
   },
   "author": "Formidable",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "sideEffects": false,
   "scripts": {
     "clean": "rimraf ./dist ./node_modules/.cache",
-    "build": "rollup -c rollup.config.js && yarn prepare:extras",
+    "build": "rollup -c rollup.config.js",
+    "postbuild": "yarn prepare:extras",
     "watch": "rollup -w -c rollup.config.js",
     "check": "tsc --noEmit",
     "test": "jest",


### PR DESCRIPTION
Pika only runs `yarn build`, this means that /extras isn't available in that build, this fixes that