### PR TITLE
Trigger updates when optimistic updates don’t match the result

### DIFF
--- a/src/cacheExchange.test.ts
+++ b/src/cacheExchange.test.ts
@@ -382,7 +382,7 @@ it('correctly clears on error', () => {
   expect(reexec).toHaveBeenCalledTimes(1);
 
   jest.runAllTimers();
-  expect(updates.Mutation.addAuthor).toHaveBeenCalledTimes(1);
+  expect(updates.Mutation.addAuthor).toHaveBeenCalledTimes(2);
   expect(response).toHaveBeenCalledTimes(2);
   expect(result).toHaveBeenCalledTimes(4);
 });

--- a/src/cacheExchange.test.ts
+++ b/src/cacheExchange.test.ts
@@ -273,6 +273,120 @@ it('writes optimistic mutations to the cache', () => {
   expect(result).toHaveBeenCalledTimes(4);
 });
 
+it('correctly clears on error', () => {
+  jest.useFakeTimers();
+
+  const authorsQuery = gql`
+    query {
+      authors {
+        id
+        name
+      }
+    }
+  `;
+
+  const authorsQueryData = {
+    __typename: 'Query',
+    authors: [
+      {
+        __typename: 'Author',
+        id: '1',
+        name: 'Author',
+      },
+    ],
+  };
+
+  const mutation = gql`
+    mutation {
+      addAuthor {
+        id
+        name
+      }
+    }
+  `;
+
+  const optimisticMutationData = {
+    __typename: 'Mutation',
+    addAuthor: {
+      __typename: 'Author',
+      id: '123',
+      name: '[REDACTED OFFLINE]',
+    },
+  };
+
+  const client = createClient({ url: '' });
+  const { source: ops$, next } = makeSubject<Operation>();
+
+  const reexec = jest
+    .spyOn(client, 'reexecuteOperation')
+    .mockImplementation(next);
+
+  const opOne = client.createRequestOperation('query', {
+    key: 1,
+    query: authorsQuery,
+  });
+
+  const opMutation = client.createRequestOperation('mutation', {
+    key: 2,
+    query: mutation,
+  });
+
+  const response = jest.fn(
+    (forwardOp: Operation): OperationResult => {
+      if (forwardOp.key === 1) {
+        return { operation: opOne, data: authorsQueryData };
+      } else if (forwardOp.key === 2) {
+        return {
+          operation: opMutation,
+          error: 'error' as any,
+          data: { __typename: 'Mutation', addAuthor: null },
+        };
+      }
+
+      return undefined as any;
+    }
+  );
+
+  const result = jest.fn();
+  const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
+
+  const optimistic = {
+    addAuthor: jest.fn(() => optimisticMutationData.addAuthor) as any,
+  };
+
+  const updates = {
+    Mutation: {
+      addAuthor: jest.fn((data, _, cache) => {
+        cache.updateQuery({ query: authorsQuery }, (prevData: any) => ({
+          ...prevData,
+          authors: [...prevData.authors, data.addAuthor],
+        }));
+      }),
+    },
+  };
+
+  pipe(
+    cacheExchange({ optimistic, updates })({ forward, client })(ops$),
+    tap(result),
+    publish
+  );
+
+  next(opOne);
+  jest.runAllTimers();
+  expect(response).toHaveBeenCalledTimes(1);
+
+  next(opMutation);
+  expect(response).toHaveBeenCalledTimes(1);
+  expect(optimistic.addAuthor).toHaveBeenCalledTimes(1);
+  expect(updates.Mutation.addAuthor).toHaveBeenCalledTimes(1);
+  expect(reexec).toHaveBeenCalledTimes(1);
+
+  jest.runAllTimers();
+  expect(updates.Mutation.addAuthor).toHaveBeenCalledTimes(1);
+  expect(response).toHaveBeenCalledTimes(2);
+  expect(result).toHaveBeenCalledTimes(4);
+});
+
 it('follows resolvers on initial write', () => {
   const client = createClient({ url: '' });
   const { source: ops$, next } = makeSubject<Operation>();

--- a/src/cacheExchange.ts
+++ b/src/cacheExchange.ts
@@ -233,13 +233,13 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
 
     // Clear old optimistic values from the store
     const { key } = operation;
-    const optimisticDependencies = optimisticKeysToDependencies.get(key);
     const pendingOperations = new Set<number>();
-    if (optimisticDependencies) {
-      collectPendingOperations(pendingOperations, optimisticDependencies);
-      optimisticKeysToDependencies.delete(key);
-      clearOptimistic(store.data, key);
-    }
+    collectPendingOperations(
+      pendingOperations,
+      optimisticKeysToDependencies.get(key)
+    );
+    optimisticKeysToDependencies.delete(key);
+    clearOptimistic(store.data, key);
 
     let writeDependencies: Set<string> | void;
     let queryDependencies: Set<string> | void;

--- a/src/cacheExchange.ts
+++ b/src/cacheExchange.ts
@@ -234,14 +234,16 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
     // Clear old optimistic values from the store
     const { key } = operation;
     const optimisticDependencies = optimisticKeysToDependencies.get(key);
+    const pendingOperations = new Set<number>();
     if (optimisticDependencies) {
+      collectPendingOperations(pendingOperations, optimisticDependencies);
       optimisticKeysToDependencies.delete(key);
       clearOptimistic(store.data, key);
     }
 
     let writeDependencies: Set<string> | void;
     let queryDependencies: Set<string> | void;
-    if (data !== null && data !== undefined && !error) {
+    if (data !== null && data !== undefined) {
       writeDependencies = write(store, operation, data).dependencies;
 
       if (isQuery) {
@@ -251,12 +253,9 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
       } else {
         data = query(store, operation, data).data;
       }
-    } else if (optimisticDependencies) {
-      writeDependencies = optimisticDependencies;
     }
 
     // Collect all write dependencies and query dependencies for queries
-    const pendingOperations = new Set<number>();
     collectPendingOperations(pendingOperations, writeDependencies);
     if (isQuery) {
       collectPendingOperations(pendingOperations, queryDependencies);

--- a/src/store/data.ts
+++ b/src/store/data.ts
@@ -27,6 +27,7 @@ export interface InMemoryData {
   queryRootKey: string;
   refCount: Dict<number>;
   refLock: OptimisticMap<Dict<number>>;
+  optimisticDependencies: { [key: number]: Set<string> | void };
   records: NodeMap<EntityField>;
   links: NodeMap<Link>;
   storage: StorageAdapter | null;
@@ -109,6 +110,7 @@ export const make = (queryRootKey: string): InMemoryData => ({
   links: makeNodeMap(),
   records: makeNodeMap(),
   storage: null,
+  optimisticDependencies: {},
 });
 
 /** Adds a node value to a NodeMap (taking optimistic values into account */
@@ -414,6 +416,7 @@ export const clearOptimistic = (data: InMemoryData, optimisticKey: number) => {
   delete data.refLock[optimisticKey];
   clearOptimisticNodes(data.records, optimisticKey);
   clearOptimisticNodes(data.links, optimisticKey);
+  return data.optimisticDependencies[optimisticKey];
 };
 
 /** Return an array of FieldInfo (info on all the fields and their arguments) for a given entity */

--- a/src/store/data.ts
+++ b/src/store/data.ts
@@ -27,7 +27,6 @@ export interface InMemoryData {
   queryRootKey: string;
   refCount: Dict<number>;
   refLock: OptimisticMap<Dict<number>>;
-  optimisticDependencies: { [key: number]: Set<string> | void };
   records: NodeMap<EntityField>;
   links: NodeMap<Link>;
   storage: StorageAdapter | null;
@@ -110,7 +109,6 @@ export const make = (queryRootKey: string): InMemoryData => ({
   links: makeNodeMap(),
   records: makeNodeMap(),
   storage: null,
-  optimisticDependencies: {},
 });
 
 /** Adds a node value to a NodeMap (taking optimistic values into account */
@@ -416,7 +414,6 @@ export const clearOptimistic = (data: InMemoryData, optimisticKey: number) => {
   delete data.refLock[optimisticKey];
   clearOptimisticNodes(data.records, optimisticKey);
   clearOptimisticNodes(data.links, optimisticKey);
-  return data.optimisticDependencies[optimisticKey];
 };
 
 /** Return an array of FieldInfo (info on all the fields and their arguments) for a given entity */


### PR DESCRIPTION
This outlines the issue in https://github.com/FormidableLabs/urql-exchange-graphcache/issues/159 and fixes it

This serves as a POC, we can fine-tune it if we agree on the method.

TODO: add test asserting correct dependencies are called on optimistic-removal with erroneous result